### PR TITLE
Support attribute as charging indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ Card code is very small - less than 10KB. It **doesn't** depend on external depe
 ### Card config
 | Name | Type | Default | Since | Description |
 |:-----|:-----|:-----|:-----|:-----|
-| type **(required)** | string | | v0.9.0 | Must be `custom:battery-state-card` |
-| entities **(required)** | string[ ] \| [Entity](#entity-object)[ ] |  | v0.9.0 | List of entities
+| type | string | **(required)** | v0.9.0 | Must be `custom:battery-state-card` |
+| entities | list([Entity](#entity-object)) | **(required)** | v0.9.0 | List of entities
 | name | string |  | v0.9.0 | Card title
 | sort_by_level | string |  | v0.9.0 | Values: `asc`, `desc`
 | collapse | number |  | v1.0.0 | Number of entities to show. Rest will be available in expandable section ([example](#sorted-list-and-collapsed-view))
@@ -26,7 +26,7 @@ Card code is very small - less than 10KB. It **doesn't** depend on external depe
 ### Entity object
 | Name | Type | Default | Since | Description |
 |:-----|:-----|:-----|:-----|:-----|
-| entity **(required)** | string |  | v0.9.0 | Entity ID
+| entity | string | **(required)** | v0.9.0 | Entity ID
 | name | string | | v0.9.0 | Entity name override
 | attribute | string | | v0.9.0 | Name of attribute (override) to extract the value from. By default we look for values in the following attributes: `battery_level`, `battery`. If they are not present we take entity state.
 | multiplier | number | `1` | v0.9.0 | If the value is not in 0-100 range we can adjust it by specifying multiplier. E.g. if the values are in 0-10 range you can make them working by putting `10` as multiplier.
@@ -37,17 +37,17 @@ Card code is very small - less than 10KB. It **doesn't** depend on external depe
 
 | Name | Type | Default | Since | Description |
 |:-----|:-----|:-----|:-----|:-----|
-| color_thresholds | [Threshold](#threshold-object)[ ] | (see [below](#default-thresholds)) | v0.9.0 | Thresholds and colors for indication of battery level.
-| color_gradient | array(string) | | v0.9.0 | Array of hex HTML colors. At least two. In #XXXXXX format, eg. `"#FFB033"`.
+| color_thresholds | list([Threshold](#threshold-object)) | (see [below](#default-thresholds)) | v0.9.0 | Thresholds and colors for indication of battery level.
+| color_gradient | list(string) | | v0.9.0 | List of hex HTML colors. At least two. In #XXXXXX format, eg. `"#FFB033"`.
 | tap_action | [TapAction](#tap-action) |  | v1.1.0 | Action that will be performed when this entity is tapped.
-| state_map | [StateMap](#state-map)[ ]|  | v1.1.0 | Collection of value mappings. It is useful if your sensor doesn't produce numeric values. ([example](#non-numeric-state-values))
+| state_map | list([StateMap](#state-map))|  | v1.1.0 | Collection of value mappings. It is useful if your sensor doesn't produce numeric values. ([example](#non-numeric-state-values))
 | charging_state | [ChargingState](#charging-state-object) |  | v1.1.0 | Configuration for charging indication. ([example](#charging-state-indicators))
 
 ### Threshold object
 
 | Name | Type | Default | Since | Description |
 |:-----|:-----|:-----|:-----|:-----|
-| value **(required)** | number |  | v0.9.0 | Threshold value
+| value | number | **(required)** | v0.9.0 | Threshold value
 | color | string | `inherit` | v0.9.0 | CSS color which will be used for levels below or equal the value field. If not specified the default one is used (default icon/text color for current HA theme)
 
 #### Default thresholds
@@ -65,33 +65,33 @@ The definition is similar to the default [tap-action](https://www.home-assistant
 |:-----|:-----|:-----|:-----|
 | action | string | `none` | Action type, one of the following: `more-info`, `call-service`, `navigate`, `url`, `none`
 | service | string |  | Service to call when `action` defined as `call-service`. Eg. `"notify.pushover"`
-| service_data | object |  | Service data to inlclue when `action` defined as `call-service`
+| service_data | any |  | Service data to inlclue when `action` defined as `call-service`
 | navigation_path | string |  | Path to navigate to when `action` defined as `navigate`. Eg. `"/lovelace/0"`
-| url_path | string |  | Uel to navigate to when `action` defined as `url`. Eg. `"https://www.home-assistant.io"`
+| url_path | string |  | Url to navigate to when `action` defined as `url`. Eg. `"https://www.home-assistant.io"`
 
 ### State map
 
 | Name | Type | Default | Description |
 |:-----|:-----|:-----|:-----|
-| from **(required)** | any |  | Value to convert. Note it is type sensitive (eg. `false` != `"false"`)
-| to **(required)** | number |  | Target battery level value in `0-100` range
+| from | any | **(required)** | Value to convert. Note it is type sensitive (eg. `false` != `"false"`)
+| to | number | **(required)** | Target battery level value in `0-100` range
 
 ### Charging-state object
 
-All of these values are optional but at least `entity_id` or `state` is required.
+Note: All of these values are optional but at least `entity_id` or `state` or `attribute` is required.
 
 | Name | Type | Default | Since | Description |
 |:-----|:-----|:-----|:-----|:-----|
 | entity_id | string |  | v1.1.0 | Other entity id where chargign state can be found
-| attribute | [Attribute](#attribute-object) \| [Attribute](#attribute-object)[ ] |  | v1.2.0 | Name of attribute to extract the value from
-| state | any \| any[ ] |  | v1.1.0 | Value indicating charging in progress
-| icon | string |  | v1.1.0 | Icon override - to show when charging is in progress
+| attribute | list([Attribute](#attribute-object)) |  | v1.2.0 | List of attribute name-values indicating charging in progress
+| state | list(any) |  | v1.1.0 | List of values indicating charging in progress
+| icon | string |  | v1.1.0 | Icon to show when charging is in progress
 
 ### Attribute object
 
 | Name | Type | Default | Description |
 |:-----|:-----|:-----|:-----|:-----|
-| name | string |  | Name of the attribute
+| name | string | **(required)** | Name of the attribute
 | value | string |  | Value of the attribute
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Card code is very small - less than 10KB. It **doesn't** depend on external depe
 | Name | Type | Default | Since | Description |
 |:-----|:-----|:-----|:-----|:-----|
 | type **(required)** | string | | v0.9.0 | Must be `custom:battery-state-card` |
-| entities **(required)** | array(string \| [Entity](#entity-object)) |  | v0.9.0 | List of entities
+| entities **(required)** | string[ ] \| [Entity](#entity-object)[ ] |  | v0.9.0 | List of entities
 | name | string |  | v0.9.0 | Card title
 | sort_by_level | string |  | v0.9.0 | Values: `asc`, `desc`
 | collapse | number |  | v1.0.0 | Number of entities to show. Rest will be available in expandable section ([example](#sorted-list-and-collapsed-view))
@@ -32,7 +32,7 @@ Card code is very small - less than 10KB. It **doesn't** depend on external depe
 | attribute | string | | v0.9.0 | Name of attribute (override) to extract the value from. By default we look for values in the following attributes: `battery_level`, `battery`. If they are not present we take entity state.
 | multiplier | number | `1` | v0.9.0 | If the value is not in 0-100 range we can adjust it by specifying multiplier. E.g. if the values are in 0-10 range you can make them working by putting `10` as multiplier.
 | tap_action | [TapAction](#tap-action) |  | v1.1.0 | Action that will be performed when this entity is tapped.
-| state_map | array([StateMap](#state-map)) |  | v1.1.0 | Collection of value mappings. It is useful if your sensor doesn't produce numeric values. ([example](#non-numeric-state-values))
+| state_map | [StateMap](#state-map)[ ]|  | v1.1.0 | Collection of value mappings. It is useful if your sensor doesn't produce numeric values. ([example](#non-numeric-state-values))
 | charging_state | [ChargingState](#charging-state-object) |  | v1.1.0 | Configuration for charging indication. ([example](#charging-state-indicators))
 
  +[appearance options](#appearance-options)
@@ -41,7 +41,7 @@ Card code is very small - less than 10KB. It **doesn't** depend on external depe
 
 | Name | Type | Default | Since | Description |
 |:-----|:-----|:-----|:-----|:-----|
-| color_thresholds | array([Threshold](#threshold-object)) | (see [below](#default-thresholds)) | v0.9.0 | Thresholds and colors for indication of battery level.
+| color_thresholds | [Threshold](#threshold-object)[ ] | (see [below](#default-thresholds)) | v0.9.0 | Thresholds and colors for indication of battery level.
 | color_gradient | array(string) | | v0.9.0 | Array of hex HTML colors. At least two. In #XXXXXX format, eg. `"#FFB033"`.
 
 ### Threshold object
@@ -81,11 +81,19 @@ The definition is similar to the default [tap-action](https://www.home-assistant
 
 All of these values are optional but at least `entity_id` or `state` is required.
 
+| Name | Type | Default | Since | Description |
+|:-----|:-----|:-----|:-----|:-----|
+| entity_id | string |  | v1.1.0 | Other entity id where chargign state can be found
+| attribute | [Attribute](#attribute-object) \| [Attribute](#attribute-object)[ ] |  | v1.2.0 | Name of attribute to extract the value from
+| state | any \| any[ ] |  | v1.1.0 | Value indicating charging in progress
+| icon | string |  | v1.1.0 | Icon override - to show when charging is in progress
+
+### Attribute object
+
 | Name | Type | Default | Description |
-|:-----|:-----|:-----|:-----|
-| entity_id | string |  | Other entity id where chargign state can be found
-| state | any |  | State value indicating charging in progress
-| icon | string |  | Icon override - to show when charging is in progress
+|:-----|:-----|:-----|:-----|:-----|
+| name | string |  | Name of the attribute
+| value | string |  | Value of the attribute
 
 ## Examples
 
@@ -269,14 +277,19 @@ If your device provides charging state you can configure it in the following way
   title: "Charging indicators"
   entities:
     - entity: sensor.device_battery_numeric
-      charging_state:
+      charging_state: # uses other entity state value
         entity_id: binary_sensor.device_charging
         state: "on"
     - entity: sensor.mi_roborock
-      charging_state:
+      charging_state: # uses sensor.mi_roborock state value
         state: "charging"
         icon: "mdi:flash"
         color: "yellow"
+    - entity: sensor.samsung
+      charging_state: # uses is_charging attribute on sensor.samsung entity
+        attribute:
+          name: "is_charging"
+          value: "yes"
 ```
 
 ### Filtering with entity-filter card

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Card view is useful when you want to have cleaner config (you don't need to dupl
 
 ```yaml
 - type: custom:battery-state-card
-  name: "Battery levels"
+  title: "Battery levels"
   entities:
     - sensor.bathroom_motion_battery_level
     - sensor.bedroom_balcony_battery_level
@@ -139,6 +139,7 @@ Entity view is useful when you want to add battery status next to other sensors 
 
 ```yaml
 - type: custom:battery-state-card
+  title: "Custom color thresholds"
   thresholds:
     - value: 35 # applied to all values below/equal
       color: "#8fffe1"
@@ -167,7 +168,7 @@ Entity view is useful when you want to add battery status next to other sensors 
 
 ```yaml
 - type: custom:battery-state-card
-  name: "Color gradient"
+  title: "Color gradient"
   color_gradient:
     - "#ff0000" # red
     - "#ffff00" # yellow
@@ -193,7 +194,7 @@ When you put empty array in `color_thresholds` property you can disable colors.
 
 ```yaml
 - type: custom:battery-state-card
-  name: "No color"
+  title: "No color"
   color_thresholds: []
   entities:
     - sensor.bedroom_motion_battery_level
@@ -209,7 +210,7 @@ You can setup as well colors only for lower battery levels and leave the default
 
 ```yaml
 - type: custom:battery-state-card
-  name: "No color - selective"
+  title: "No color - selective"
   color_thresholds:
     - value: 20
       color: "red"
@@ -229,7 +230,7 @@ You can setup as well colors only for lower battery levels and leave the default
 
 ```yaml
 - type: custom:battery-state-card
-  name: "Sorted list and collapsed view"
+  title: "Sorted list and collapsed view"
   sort_by_level: "asc"
   collapse: 4
   entities:
@@ -246,7 +247,7 @@ If your sensor doesn't produce numeric values you can use `state_map` property a
 
 ```yaml
 - type: custom:battery-state-card
-  name: String values - state map
+  title: "String values - state map"
   entities:
     - entity: binary_sensor.battery_state
       name: "Binary sensor state"
@@ -334,7 +335,7 @@ If you want to see batteries (or card) only if they are below specific threshold
       value: 100
   card:
     type: custom:battery-state-card
-    name: Filtering with entity-filter
+    title: Filtering with entity-filter
     color_gradient:
       - "#ff0000" # red
       - "#0000ff" # blue

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Card code is very small - less than 10KB. It **doesn't** depend on external depe
 | sort_by_level | string |  | v0.9.0 | Values: `asc`, `desc`
 | collapse | number |  | v1.0.0 | Number of entities to show. Rest will be available in expandable section ([example](#sorted-list-and-collapsed-view))
 
-+[common options](#common-options)
++[common options](#common-options) (if specified they will be apllied to all entities)
 
 
 ### Entity object
@@ -31,7 +31,7 @@ Card code is very small - less than 10KB. It **doesn't** depend on external depe
 | attribute | string | | v0.9.0 | Name of attribute (override) to extract the value from. By default we look for values in the following attributes: `battery_level`, `battery`. If they are not present we take entity state.
 | multiplier | number | `1` | v0.9.0 | If the value is not in 0-100 range we can adjust it by specifying multiplier. E.g. if the values are in 0-10 range you can make them working by putting `10` as multiplier.
 
- +[common options](#common-options)
+ +[common options](#common-options) (if specified they will override the card-level ones)
 
 ### Common options
 

--- a/README.md
+++ b/README.md
@@ -19,9 +19,8 @@ Card code is very small - less than 10KB. It **doesn't** depend on external depe
 | name | string |  | v0.9.0 | Card title
 | sort_by_level | string |  | v0.9.0 | Values: `asc`, `desc`
 | collapse | number |  | v1.0.0 | Number of entities to show. Rest will be available in expandable section ([example](#sorted-list-and-collapsed-view))
-| tap_action | [TapAction](#tap-action) |  | v1.1.0 | Action that will be performed when an entity on card is tapped. This action will be applied to all entities on the card (unless the `tap_action` is specified explicitly in [Entity](#entity-object))
 
-+[appearance options](#appearance-options)
++[common options](#common-options)
 
 
 ### Entity object
@@ -31,18 +30,18 @@ Card code is very small - less than 10KB. It **doesn't** depend on external depe
 | name | string | | v0.9.0 | Entity name override
 | attribute | string | | v0.9.0 | Name of attribute (override) to extract the value from. By default we look for values in the following attributes: `battery_level`, `battery`. If they are not present we take entity state.
 | multiplier | number | `1` | v0.9.0 | If the value is not in 0-100 range we can adjust it by specifying multiplier. E.g. if the values are in 0-10 range you can make them working by putting `10` as multiplier.
-| tap_action | [TapAction](#tap-action) |  | v1.1.0 | Action that will be performed when this entity is tapped.
-| state_map | [StateMap](#state-map)[ ]|  | v1.1.0 | Collection of value mappings. It is useful if your sensor doesn't produce numeric values. ([example](#non-numeric-state-values))
-| charging_state | [ChargingState](#charging-state-object) |  | v1.1.0 | Configuration for charging indication. ([example](#charging-state-indicators))
 
- +[appearance options](#appearance-options)
+ +[common options](#common-options)
 
-### Appearance options
+### Common options
 
 | Name | Type | Default | Since | Description |
 |:-----|:-----|:-----|:-----|:-----|
 | color_thresholds | [Threshold](#threshold-object)[ ] | (see [below](#default-thresholds)) | v0.9.0 | Thresholds and colors for indication of battery level.
 | color_gradient | array(string) | | v0.9.0 | Array of hex HTML colors. At least two. In #XXXXXX format, eg. `"#FFB033"`.
+| tap_action | [TapAction](#tap-action) |  | v1.1.0 | Action that will be performed when this entity is tapped.
+| state_map | [StateMap](#state-map)[ ]|  | v1.1.0 | Collection of value mappings. It is useful if your sensor doesn't produce numeric values. ([example](#non-numeric-state-values))
+| charging_state | [ChargingState](#charging-state-object) |  | v1.1.0 | Configuration for charging indication. ([example](#charging-state-indicators))
 
 ### Threshold object
 

--- a/README.md
+++ b/README.md
@@ -291,6 +291,26 @@ If your device provides charging state you can configure it in the following way
           value: "yes"
 ```
 
+Card-level charging state configuration
+
+```yaml
+- type: custom:battery-state-card
+  title: "Charging indicators"
+  charging_state:
+    attribute: # whenever one of below attributes is matching
+      - name: "Battery State"
+        value: "Charging"
+      - name: "is_charging"
+        value: true
+    state: # or if entity state matches one of the following
+      - "charging"
+      - "Charging"
+  entities:
+    - sensor.device_battery_numeric
+    - sensor.mi_roborock
+    - sensor.samsung
+```
+
 ### Filtering with entity-filter card
 
 If you want to see batteries (or card) only if they are below specific threshold you can use [entity-filter](https://www.home-assistant.io/lovelace/entity-filter/) card combined with this card.

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Note: All of these values are optional but at least `entity_id` or `state` or `a
 ### Attribute object
 
 | Name | Type | Default | Description |
-|:-----|:-----|:-----|:-----|:-----|
+|:-----|:-----|:-----|:-----|
 | name | string | **(required)** | Name of the attribute
 | value | string |  | Value of the attribute
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Card code is very small - less than 10KB. It **doesn't** depend on external depe
 |:-----|:-----|:-----|:-----|:-----|
 | type | string | **(required)** | v0.9.0 | Must be `custom:battery-state-card` |
 | entities | list([Entity](#entity-object)) | **(required)** | v0.9.0 | List of entities
-| name | string |  | v0.9.0 | Card title
+| title | string |  | v0.9.0 | Card title
 | sort_by_level | string |  | v0.9.0 | Values: `asc`, `desc`
 | collapse | number |  | v1.0.0 | Number of entities to show. Rest will be available in expandable section ([example](#sorted-list-and-collapsed-view))
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "battery-state-card",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Battery State card for Home Assistant",
   "main": "dist/battery-state-card.js",
   "repository": {

--- a/src/battery-vm.ts
+++ b/src/battery-vm.ts
@@ -214,7 +214,9 @@ class BatteryViewModel {
             // take first attribute name which exists on entity
             const exisitngAttrib = attributesLookup.find(attr => entityWithChargingState.attributes[attr.name] != undefined);
             if (exisitngAttrib) {
-                this.charging = entityWithChargingState.attributes[exisitngAttrib.name] == exisitngAttrib.value;
+                this.charging = exisitngAttrib.value != undefined ?
+                    entityWithChargingState.attributes[exisitngAttrib.name] == exisitngAttrib.value :
+                    true;
                 return;
             }
         }

--- a/src/ha-types.ts
+++ b/src/ha-types.ts
@@ -159,13 +159,18 @@ export interface ToggleActionConfig extends BaseActionConfig {
     nativeName: string;
     isRTL: boolean;
     fingerprints: { [fragment: string]: string };
-  }
+}
+
+export interface HassEntity {
+  attributes: { [key: string]: any };
+  state: any;
+}
 
   export interface HomeAssistant {
     auth: any;// Auth;
     connection: any;// Connection;
     connected: any;// boolean;
-    states: any;// HassEntities;
+    states: { [entity_id: string]: HassEntity };
     services: any;// HassServices;
     config: any;// HassConfig;
     themes: Themes;

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,7 +103,7 @@ class BatteryStateCard extends LitElement {
         const batteryViews = this.batteries.map(battery => views.battery(battery));
 
         return views.card(
-            this.config.name,
+            this.config.name || this.config.title,
             this.config.collapse ? [ views.collapsableWrapper(batteryViews, this.config.collapse) ] : batteryViews
         );
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,8 +38,7 @@ class BatteryStateCard extends LitElement {
      */
     static get properties() {
         return {
-            batteries: Array,
-            config: Object
+            batteries: Array
         };
     }
 
@@ -69,31 +68,10 @@ class BatteryStateCard extends LitElement {
 
         this.rawConfig = rawConfig;
 
-        this.config = config;
-        this.simpleView = !!config.entity;
+        // config is readonly and we want to apply default values so we need to recreate it
+        this.config = JSON.parse(rawConfig);
 
-        let entities = config.entity
-            ? [config]
-            : config.entities!.map((entity: string | IBatteryEntity) => {
-                // check if it is just the id string
-                if (typeof (entity) === "string") {
-                    entity = <IBatteryEntity>{ entity: entity };
-                }
-
-                return entity;
-            });
-
-        this.batteries = entities.map(entity =>
-            new BatteryViewModel(
-                entity,
-                this.config,
-                ActionFactory.getAction({
-                    card: <any>this,
-                    config: entity.tap_action || this.config.tap_action || <any>null,
-                    entity: entity
-                })
-            )
-        );
+        this.onConfigUpdate();
     }
 
     /**
@@ -146,6 +124,41 @@ class BatteryStateCard extends LitElement {
 
         // +1 to account header
         return size + 1;
+    }
+
+    /**
+     * Updates batteries based on the new config
+     */
+    private async onConfigUpdate() {
+        this.simpleView = !!this.config.entity;
+
+        let entities = this.config.entity
+            ? [this.config]
+            : this.config.entities!.map((entity: string | IBatteryEntity) => {
+                // check if it is just the id string
+                if (typeof (entity) === "string") {
+                    entity = <IBatteryEntity>{ entity: entity };
+                }
+
+                return entity;
+            });
+
+        const entititesGlobalProps = [ "tap_action", "state_map", "charging_state", "color_thresholds", "color_gradient" ];
+        this.batteries = entities.map(entity => {
+            // assing card-level values if they were not defined on entity-level
+            entititesGlobalProps
+                .filter(p => (<any>entity)[p] == undefined)
+                .forEach(p => (<any>entity)[p] = (<any>this.config)[p]);
+
+            return new BatteryViewModel(
+                entity,
+                ActionFactory.getAction({
+                    card: <any>this,
+                    config: entity.tap_action || this.config.tap_action || <any>null,
+                    entity: entity
+                })
+            );
+        });
     }
 
     /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,9 +19,15 @@ export interface IStateMap {
     to: number;
 }
 
+interface IAttribute {
+    name: string;
+    value: any;
+}
+
 interface IChargingState {
     entity_id?: string;
-    state?: string;
+    state?: string | string[];
+    attribute?: IAttribute | IAttribute[];
     icon?: string;
     color?: string;
 }
@@ -33,16 +39,13 @@ export interface IBatteryEntity {
     multiplier?: number;
     tap_action?: IActionConfig;
     state_map?: IStateMap[];
-    charging_state: IChargingState;
+    charging_state?: IChargingState;
     value_override?: string; // dev purposes only
-}
-
-export interface IAppearance {
     color_thresholds?: IColorThreshold[];
     color_gradient?: string[];
 }
 
-export interface IBatteryStateCardConfig extends IBatteryEntity, IAppearance  {
+export interface IBatteryStateCardConfig extends IBatteryEntity  {
     entities: IBatteryEntity[];
     sort_by_level?: "asc" | "desc";
     collapse?: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,7 +34,8 @@ interface IChargingState {
 
 export interface IBatteryEntity {
     entity: string;
-    name?: string;
+    name?: string; // deprecated
+    title?: string;
     attribute?: string;
     multiplier?: number;
     tap_action?: IActionConfig;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -65,3 +65,21 @@ export const getColorInterpolationForPercentage = function (colors: string[], pc
     };
     return "rgb(" + [color.r, color.g, color.b].join(",") + ")";
 };
+
+/**
+ * Checks whether given value is a number
+ * @param val String value to check
+ */
+export const isNumber = (val: string) => !isNaN(Number(val));
+
+/**
+ * Returns array of values regardles if given value is string array or null
+ * @param val Value to process
+ */
+export const safeGetArray = <T>(val: T | T[] | undefined): T[] => {
+    if (Array.isArray(val)) {
+        return val;
+    }
+
+    return val ? [val] : [];
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,6 @@
 
 console.info(
-    "%c BATTERY-STATE-CARD %c 1.1.1",
+    "%c BATTERY-STATE-CARD %c 1.2.0",
     "color: white; background: forestgreen; font-weight: 700;",
     "color: forestgreen; background: white; font-weight: 700;",
 );

--- a/src/views.ts
+++ b/src/views.ts
@@ -1,5 +1,6 @@
 import { html } from "./lit-element";
 import BatteryViewModel from "./battery-vm";
+import { isNumber } from "./utils";
 
 
 const header = (text: string) => html`
@@ -23,7 +24,7 @@ export const battery = (model: BatteryViewModel) => html`
         ${model.name}
     </div>
     <div class="state">
-        ${model.level}${isNaN(Number(model.level)) ? "" : html`&nbsp;%`}
+        ${model.level}${isNumber(model.level) ? html`&nbsp;%` : ""}
     </div>
 </div>
 `;


### PR DESCRIPTION
Currently it was not possible to use attribute value to check whether charging is in progress. I'm adding a way to add collection of attribute name-values which can be used as charging indication.

Covering #31 