### PR TITLE
fix(style): use secondary-text-color for secondary_info to respect themes

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -26,7 +26,7 @@
     margin: 0 6px;
 }
 .entity-row .secondary {
-    color: var(--primary-color);
+    color: var(--secondary-text-color);
 }
 .entity-row .icon {
     flex: 0 0 40px;


### PR DESCRIPTION
Home assistant entity list is using `secondary-text-color` to set the secondary_info color. This should be respected to be themable and consistent to HA default behaviour