### PR TITLE
Add additional common option documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ This card was inspired by [another great card](https://github.com/cbulock/lovela
  +[common options](#common-options) (if specified they will override the card-level ones)
 
 ### Common options
+These options can be specified both per-entity and at the top level (affecting all entities).
 
 | Name | Type | Default | Since | Description |
 |:-----|:-----|:-----|:-----|:-----|


### PR DESCRIPTION
I'm not 100% set on the wording I've used here, but I think adding where it can be used beneath the common options heading (as well as under the headings it can be used, which has already been done) should make it a bit more discoverable.

Related: #255 