### PR TITLE
Don't prioritize higher battery_level attribute (over the state) if its value is not a number

### DIFF
--- a/src/custom-elements/battery-state-entity.ts
+++ b/src/custom-elements/battery-state-entity.ts
@@ -71,7 +71,7 @@ export class BatteryStateEntity extends LovelaceCard<IBatteryEntityConfig> {
     public static get styles() {
         return css(<any>[sharedStyles + entityStyles]);
     }
-    
+
     async internalUpdate() {
         this.name = getName(this.config, this.hass);
         this.state = getBatteryLevel(this.config, this.hass);
@@ -119,7 +119,7 @@ export class BatteryStateEntity extends LovelaceCard<IBatteryEntityConfig> {
                         entityId: this.config.entity,
                     }, this.hass!);
                 }
-    
+
                 this.addEventListener("click", this.action);
                 this.classList.add("clickable");
             }
@@ -231,7 +231,9 @@ const getBatteryLevel = (config: IBatteryEntityConfig, hass?: HomeAssistant): st
             entityData.state
         ];
 
-        level = candidates.find(n => n !== null && n !== undefined)?.toString() || UnknownLevel;
+        level = candidates.find(val => isNumber(val)) ||
+                candidates.find(val => val !== null && val !== undefined)?.toString() ||
+                UnknownLevel
     }
 
     // check if we should convert value eg. for binary sensors

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -69,8 +69,10 @@ export const getColorInterpolationForPercentage = function (colors: string[], pc
  * Checks whether given value is a number
  * @param val String value to check
  */
-export const isNumber = (val: string) => !isNaN(Number(val));
-
+export const isNumber = (value: string | number): boolean =>
+    {
+        return (value !== null && value !== '' && !isNaN(Number(value)))
+    }
 /**
  * Returns array of values regardles if given value is string array or null
  * @param val Value to process


### PR DESCRIPTION
This attempts a first pass at addressing #382 by first passing through the collection of possible places for the battery percentage to hide and if it finds a numeric, use that first (then use the current checks)

Of course, it could be possible to make this more sophisticated, or allow overrides per entity, but on a first pass on my home assistant, it resulted in a lot more of what I wanted to see (percentage values) and a lot less of what I didn't want to see.

Tests pass and code compiles, no dependencies