### PR TITLE
Fix numbers in secondary info

### DIFF
--- a/src/custom-elements/battery-state-entity.ts
+++ b/src/custom-elements/battery-state-entity.ts
@@ -9,6 +9,7 @@ import entityStyles from "./battery-state-entity.css";
 import { handleAction } from "../action";
 import { RichStringProcessor } from "../rich-string-processor";
 import { getColorForBatteryLevel } from "../colors";
+import { getSecondaryInfo } from "../entity-fields/get-secondary-info";
 
 /**
  * Some sensor may produce string value like "45%". This regex is meant to parse such values.
@@ -160,28 +161,6 @@ const getName = (config: IBatteryEntityConfig, hass: HomeAssistant | undefined):
     });
 
     return name;
-}
-
-/**
- * Gets secondary info text
- * @param config Entity config
- * @param hass HomeAssistant state object
- * @param isCharging Whther battery is in charging mode
- * @returns Secondary info text
- */
-const getSecondaryInfo = (config: IBatteryEntityConfig, hass: HomeAssistant | undefined, isCharging: boolean): string | Date => {
-    if (config.secondary_info) {
-        const processor = new RichStringProcessor(hass, config.entity, {
-            "charging": isCharging ? (config.charging_state?.secondary_info_text || "Charging") : "" // todo: think about i18n
-        });
-
-        let result = processor.process(config.secondary_info);
-
-        const dateVal = Date.parse(result);
-        return isNaN(dateVal) ? result : new Date(dateVal);
-    }
-
-    return <any>null;
 }
 
 /**

--- a/src/custom-elements/battery-state-entity.views.ts
+++ b/src/custom-elements/battery-state-entity.views.ts
@@ -25,7 +25,7 @@ export const batteryHtml = (model: BatteryStateEntity) => html`
 ${icon(model.icon, model.iconColor)}
 <div class="name truncate">
     ${model.name}
-    ${typeof(model.secondaryInfo) == "string" ? secondaryInfo(model.secondaryInfo) : secondaryInfoTime(model.hass, model.secondaryInfo)}
+    ${model.secondaryInfo instanceof Date ? secondaryInfoTime(model.hass, model.secondaryInfo) : secondaryInfo(model.secondaryInfo)}
 </div>
 <div class="state">
     ${model.state}${model.unit}

--- a/src/entity-fields/get-secondary-info.ts
+++ b/src/entity-fields/get-secondary-info.ts
@@ -1,0 +1,31 @@
+import { HomeAssistant } from "custom-card-helpers/dist/types";
+import { RichStringProcessor } from "../rich-string-processor";
+import { isNumber } from "../utils";
+
+/**
+ * Gets secondary info text
+ * @param config Entity config
+ * @param hass HomeAssistant state object
+ * @param isCharging Whther battery is in charging mode
+ * @returns Secondary info text
+ */
+export const getSecondaryInfo = (config: IBatteryEntityConfig, hass: HomeAssistant | undefined, isCharging: boolean): string | Date => {
+    if (config.secondary_info) {
+        const processor = new RichStringProcessor(hass, config.entity, {
+            "charging": isCharging ? (config.charging_state?.secondary_info_text || "Charging") : "" // todo: think about i18n
+        });
+
+        let result = processor.process(config.secondary_info);
+
+        // we convert to Date in the next step where number conversion to date is valid too
+        // although in such cases we want to return the number - not a date
+        if (isNumber(result)) {
+            return result;
+        }
+
+        const dateVal = Date.parse(result);
+        return isNaN(dateVal) ? result : new Date(dateVal);
+    }
+
+    return <any>null;
+}

--- a/src/rich-string-processor.ts
+++ b/src/rich-string-processor.ts
@@ -85,7 +85,7 @@ const validEntityDomains = ["sensor", "binary_sensor"];
             data = JSON.stringify(data);
         }
 
-        return data.toString();
+        return data === undefined ? undefined : data.toString();
     }
 }
 

--- a/test/other/entity-fields/get-secondary-info.test.ts
+++ b/test/other/entity-fields/get-secondary-info.test.ts
@@ -1,0 +1,34 @@
+import { getSecondaryInfo } from "../../../src/entity-fields/get-secondary-info"
+import { HomeAssistantMock } from "../../helpers"
+
+describe("Secondary info", () => {
+
+    test("Unsupported entity domain", () => {
+        const hassMock = new HomeAssistantMock(true);
+        const entity = hassMock.addEntity("Motion sensor kitchen", "50", {}, "device_tracker");
+        const secondaryInfoConfig = "{" + entity.entity_id + "}";
+        const result = getSecondaryInfo({ entity: "any", secondary_info: secondaryInfoConfig }, hassMock.hass, false);
+
+        expect(result).toBe("{device_tracker.motion_sensor_kitchen}");
+    })
+
+    test("Other entity state (number)", () => { 
+        const hassMock = new HomeAssistantMock(true);
+        const entity = hassMock.addEntity("Motion sensor kitchen", "50", {}, "sensor");
+        const secondaryInfoConfig = "{" + entity.entity_id + ".state}";
+        const result = getSecondaryInfo({ entity: "any", secondary_info: secondaryInfoConfig }, hassMock.hass, false);
+
+        expect(result).toBe("50");
+    })
+
+    test("Attribute 'last_changed'", () => { 
+        const hassMock = new HomeAssistantMock(true);
+        const entity = hassMock.addEntity("Motion sensor kitchen", "50", {}, "sensor");
+        entity.setLastChanged("2022-02-07");
+        const secondaryInfoConfig = "{last_changed}";
+        const result = getSecondaryInfo({ entity: entity.entity_id, secondary_info: secondaryInfoConfig }, hassMock.hass, false);
+
+        expect(result).toBeInstanceOf(Date);
+        expect(JSON.stringify(result).slice(1, -1)).toBe("2022-02-07T00:00:00.000Z");
+    })
+})


### PR DESCRIPTION
When number was set in secondary info (e.g. coming from the other entity or attribute) it was converted to Date as Date.parse([number]) returns a valid Date object.