### PR TITLE
Downgrading Lit package - fixes missing card in old browsers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "custom-card-helpers": "^1.9.0",
-        "lit": "^3.0.0"
+        "lit": "^2.8.0"
       },
       "devDependencies": {
         "@rollup/plugin-node-resolve": "^15.2.3",
@@ -710,11 +710,11 @@
       "integrity": "sha512-jnOD+/+dSrfTWYfSXBXlo5l5f0q1UuJo3tkbMDCYA2lKUYq79jaxqtGEvnRoh049nt1vdo1+45RinipU6FGY2g=="
     },
     "node_modules/@lit/reactive-element": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.0.0.tgz",
-      "integrity": "sha512-wn+2+uDcs62ROBmVAwssO4x5xue/uKD3MGGZOXL2sMxReTRIT0JXKyMXeu7gh0aJ4IJNEIG/3aOnUaQvM7BMzQ==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
+      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
       "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.1.2-pre.0"
+        "@lit-labs/ssr-dom-shim": "^1.0.0"
       }
     },
     "node_modules/@rollup/plugin-node-resolve": {
@@ -1995,42 +1995,6 @@
         "rollup": "^2.63.0",
         "superstruct": "^0.15.3",
         "typescript": "^4.5.4"
-      }
-    },
-    "node_modules/custom-card-helpers/node_modules/@lit/reactive-element": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
-      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.0.0"
-      }
-    },
-    "node_modules/custom-card-helpers/node_modules/lit": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
-      "integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
-      "dependencies": {
-        "@lit/reactive-element": "^1.6.0",
-        "lit-element": "^3.3.0",
-        "lit-html": "^2.8.0"
-      }
-    },
-    "node_modules/custom-card-helpers/node_modules/lit-element": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
-      "integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.1.0",
-        "@lit/reactive-element": "^1.3.0",
-        "lit-html": "^2.8.0"
-      }
-    },
-    "node_modules/custom-card-helpers/node_modules/lit-html": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
-      "integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
-      "dependencies": {
-        "@types/trusted-types": "^2.0.2"
       }
     },
     "node_modules/custom-card-helpers/node_modules/typescript": {
@@ -5279,29 +5243,29 @@
       }
     },
     "node_modules/lit": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-3.0.0.tgz",
-      "integrity": "sha512-nQ0teRzU1Kdj++VdmttS2WvIen8M79wChJ6guRKIIym2M3Ansg3Adj9O6yuQh2IpjxiUXlNuS81WKlQ4iL3BmA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
+      "integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
       "dependencies": {
-        "@lit/reactive-element": "^2.0.0",
-        "lit-element": "^4.0.0",
-        "lit-html": "^3.0.0"
+        "@lit/reactive-element": "^1.6.0",
+        "lit-element": "^3.3.0",
+        "lit-html": "^2.8.0"
       }
     },
     "node_modules/lit-element": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.0.0.tgz",
-      "integrity": "sha512-N6+f7XgusURHl69DUZU6sTBGlIN+9Ixfs3ykkNDfgfTkDYGGOWwHAYBhDqVswnFGyWgQYR2KiSpu4J76Kccs/A==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
+      "integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
       "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.1.2-pre.0",
-        "@lit/reactive-element": "^2.0.0",
-        "lit-html": "^3.0.0"
+        "@lit-labs/ssr-dom-shim": "^1.1.0",
+        "@lit/reactive-element": "^1.3.0",
+        "lit-html": "^2.8.0"
       }
     },
     "node_modules/lit-html": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.0.0.tgz",
-      "integrity": "sha512-DNJIE8dNY0dQF2Gs0sdMNUppMQT2/CvV4OVnSdg7BXAsGqkVwsE5bqQ04POfkYH5dBIuGnJYdFz5fYYyNnOxiA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
+      "integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
       "dependencies": {
         "@types/trusted-types": "^2.0.2"
       }
@@ -9153,11 +9117,11 @@
       "integrity": "sha512-jnOD+/+dSrfTWYfSXBXlo5l5f0q1UuJo3tkbMDCYA2lKUYq79jaxqtGEvnRoh049nt1vdo1+45RinipU6FGY2g=="
     },
     "@lit/reactive-element": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.0.0.tgz",
-      "integrity": "sha512-wn+2+uDcs62ROBmVAwssO4x5xue/uKD3MGGZOXL2sMxReTRIT0JXKyMXeu7gh0aJ4IJNEIG/3aOnUaQvM7BMzQ==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
+      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
       "requires": {
-        "@lit-labs/ssr-dom-shim": "^1.1.2-pre.0"
+        "@lit-labs/ssr-dom-shim": "^1.0.0"
       }
     },
     "@rollup/plugin-node-resolve": {
@@ -10174,42 +10138,6 @@
         "typescript": "^4.5.4"
       },
       "dependencies": {
-        "@lit/reactive-element": {
-          "version": "1.6.3",
-          "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
-          "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
-          "requires": {
-            "@lit-labs/ssr-dom-shim": "^1.0.0"
-          }
-        },
-        "lit": {
-          "version": "2.8.0",
-          "resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
-          "integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
-          "requires": {
-            "@lit/reactive-element": "^1.6.0",
-            "lit-element": "^3.3.0",
-            "lit-html": "^2.8.0"
-          }
-        },
-        "lit-element": {
-          "version": "3.3.3",
-          "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
-          "integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
-          "requires": {
-            "@lit-labs/ssr-dom-shim": "^1.1.0",
-            "@lit/reactive-element": "^1.3.0",
-            "lit-html": "^2.8.0"
-          }
-        },
-        "lit-html": {
-          "version": "2.8.0",
-          "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
-          "integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
-          "requires": {
-            "@types/trusted-types": "^2.0.2"
-          }
-        },
         "typescript": {
           "version": "4.9.5",
           "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
@@ -12763,29 +12691,29 @@
       }
     },
     "lit": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-3.0.0.tgz",
-      "integrity": "sha512-nQ0teRzU1Kdj++VdmttS2WvIen8M79wChJ6guRKIIym2M3Ansg3Adj9O6yuQh2IpjxiUXlNuS81WKlQ4iL3BmA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
+      "integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
       "requires": {
-        "@lit/reactive-element": "^2.0.0",
-        "lit-element": "^4.0.0",
-        "lit-html": "^3.0.0"
+        "@lit/reactive-element": "^1.6.0",
+        "lit-element": "^3.3.0",
+        "lit-html": "^2.8.0"
       }
     },
     "lit-element": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.0.0.tgz",
-      "integrity": "sha512-N6+f7XgusURHl69DUZU6sTBGlIN+9Ixfs3ykkNDfgfTkDYGGOWwHAYBhDqVswnFGyWgQYR2KiSpu4J76Kccs/A==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
+      "integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
       "requires": {
-        "@lit-labs/ssr-dom-shim": "^1.1.2-pre.0",
-        "@lit/reactive-element": "^2.0.0",
-        "lit-html": "^3.0.0"
+        "@lit-labs/ssr-dom-shim": "^1.1.0",
+        "@lit/reactive-element": "^1.3.0",
+        "lit-html": "^2.8.0"
       }
     },
     "lit-html": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.0.0.tgz",
-      "integrity": "sha512-DNJIE8dNY0dQF2Gs0sdMNUppMQT2/CvV4OVnSdg7BXAsGqkVwsE5bqQ04POfkYH5dBIuGnJYdFz5fYYyNnOxiA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
+      "integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
       "requires": {
         "@types/trusted-types": "^2.0.2"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "battery-state-card",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Battery State card for Home Assistant",
   "main": "dist/battery-state-card.js",
   "author": "Max Chodorowski",
@@ -82,6 +82,6 @@
   },
   "dependencies": {
     "custom-card-helpers": "^1.9.0",
-    "lit": "^3.0.0"
+    "lit": "^2.8.0"
   }
 }


### PR DESCRIPTION
#596

Looks like the old webkit browsers don't support Lit v3. Since HA team decided to stick with 2.8.0 for a while I'm doing the same and won't be upgrading until HA frontend do it