### PR TITLE
Enable custom colors for all numeric values (also outside of 0-100 range)

### DIFF
--- a/src/colors.ts
+++ b/src/colors.ts
@@ -13,7 +13,7 @@ import { log, safeGetConfigArrayOfObjects } from "./utils";
         return config.charging_state.color;
     }
 
-    if (batteryLevel === undefined || isNaN(batteryLevel) || batteryLevel > 100 || batteryLevel < 0) {
+    if (batteryLevel === undefined || isNaN(batteryLevel)) {
         return defaultColor;
     }
 

--- a/test/other/colors.test.ts
+++ b/test/other/colors.test.ts
@@ -38,6 +38,28 @@ describe("Colors", () => {
     })
 
     test.each([
+        [-220, "red"],
+        [-80, "red"],
+        [-79.9999, "yellow"],
+        [-65, "yellow"],
+        [-50, "green"],
+        [0, "green"],
+        [100, "green"],
+    ])("custom steps config", (batteryLevel: number, expectedColor: string) => {
+
+        const colorsConfig: IColorSettings = {
+            steps: [
+                { value: -80, color: "red" },
+                { value: -65, color: "yellow" },
+                { value: 1000, color: "green" }
+            ]
+        }
+        const result = getColorForBatteryLevel({ entity: "", colors: colorsConfig }, batteryLevel, false);
+
+        expect(result).toBe(expectedColor);
+    })
+
+    test.each([
         [0, "#ff0000"],
         [25, "#ff7f00"],
         [50, "#ffff00"],


### PR DESCRIPTION
Since the component can be used for other entity types than just battery (and the readme even includes such examples) I think it makes sense to remove the restriction of 0-100 range for custom colours.

This will enable full functionality when using for negative temperatures, zigbee link quality, disk space etc.