### PR TITLE
Revert "Enable custom colors for all numeric values (also outside of 0-100 range)"

### DIFF
--- a/src/colors.ts
+++ b/src/colors.ts
@@ -13,7 +13,7 @@ import { log, safeGetConfigArrayOfObjects } from "./utils";
         return config.charging_state.color;
     }
 
-    if (batteryLevel === undefined || isNaN(batteryLevel)) {
+    if (batteryLevel === undefined || isNaN(batteryLevel) || batteryLevel > 100 || batteryLevel < 0) {
         return defaultColor;
     }
 

--- a/test/other/colors.test.ts
+++ b/test/other/colors.test.ts
@@ -38,28 +38,6 @@ describe("Colors", () => {
     })
 
     test.each([
-        [-220, "red"],
-        [-80, "red"],
-        [-79.9999, "yellow"],
-        [-65, "yellow"],
-        [-50, "green"],
-        [0, "green"],
-        [100, "green"],
-    ])("custom steps config", (batteryLevel: number, expectedColor: string) => {
-
-        const colorsConfig: IColorSettings = {
-            steps: [
-                { value: -80, color: "red" },
-                { value: -65, color: "yellow" },
-                { value: 1000, color: "green" }
-            ]
-        }
-        const result = getColorForBatteryLevel({ entity: "", colors: colorsConfig }, batteryLevel, false);
-
-        expect(result).toBe(expectedColor);
-    })
-
-    test.each([
         [0, "#ff0000"],
         [25, "#ff7f00"],
         [50, "#ffff00"],


### PR DESCRIPTION
Reverts maxwroc/battery-state-card#599

Merged it too fast... now when looked at the full code:
* There is a condition below which checks whether the step value is greater than 100. So if you have a different color for 500 and 1000 it won't work. The only reason why it didn't fail in the test is that the additional step/color was missing (between 100 and 1000)
  https://github.com/maxwroc/battery-state-card/blob/3bae17c6bf67fddbb958ad4098d74b75b8426eb3/src/colors.ts#L30C48-L30C67
* If the `gradient` flag is true then it will fail as well - the `getColorInterpolationForPercentage` requires number in 0-100 range 
