### PR TITLE
KString support in entity name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "battery-state-card",
-  "version": "3.0.2",
+  "version": "3.1.0",
   "description": "Battery State card for Home Assistant",
   "main": "dist/battery-state-card.js",
   "author": "Max Chodorowski",

--- a/src/entity-fields/get-name.ts
+++ b/src/entity-fields/get-name.ts
@@ -1,5 +1,6 @@
 import { HomeAssistant } from "custom-card-helpers";
 import { getRegexFromString, safeGetArray } from "../utils";
+import { RichStringProcessor } from "../rich-string-processor";
 
 
 /**
@@ -10,7 +11,8 @@ import { getRegexFromString, safeGetArray } from "../utils";
  */
 export const getName = (config: IBatteryEntityConfig, hass: HomeAssistant | undefined): string => {
     if (config.name) {
-        return config.name;
+        const proc = new RichStringProcessor(hass, config.entity);
+        return proc.process(config.name);
     }
 
     if (!hass) {

--- a/test/other/entity-fields/get-name.test.ts
+++ b/test/other/entity-fields/get-name.test.ts
@@ -69,4 +69,18 @@ describe("Get name", () => {
 
         expect(name).toBe(expectedResult);
     });
+
+    test.each([
+        ["State in the name {state}%", "State in the name 45%"],
+        ["KString func {state|multiply(2)}%", "KString func 90%"],
+        ["KString other entity {sensor.other_entity.state}", "KString other entity CR2032"],
+    ])("KString in the name", (name: string, expectedResult: string) => {
+        const hassMock = new HomeAssistantMock(true);
+        hassMock.addEntity("My entity", "45");
+
+        hassMock.addEntity("Other entity", "CR2032", undefined, "sensor");
+
+        let result = getName({entity: "my_entity", name}, hassMock.hass);
+        expect(result).toBe(expectedResult);
+    })
 });


### PR DESCRIPTION
This way we will be able to use dynamic values in entity.name configuration.

e.g.
```yaml
- entity: sensor.my_battery
  name: "My Battery ({sensor.my_battery_type.state})"
```

The above can print for example "My Battery (CR2032)" as the entity name