### PR TITLE
Sort by numeric state (not displayed value)

### DIFF
--- a/src/custom-elements/battery-state-entity.ts
+++ b/src/custom-elements/battery-state-entity.ts
@@ -66,6 +66,11 @@ export class BatteryStateEntity extends LovelaceCard<IBatteryEntityConfig> {
     public entityData: IMap<string>;
 
     /**
+     * Numeric representation of the state
+     */
+    public stateNumeric: number | undefined;
+
+    /**
      * Entity CSS styles
      */
     public static get styles() {
@@ -81,6 +86,7 @@ export class BatteryStateEntity extends LovelaceCard<IBatteryEntityConfig> {
         var { state, level, unit} = getBatteryLevel(this.config, this.hass);
         this.state = state;
         this.unit = unit;
+        this.stateNumeric = level;
         
         const isCharging = getChargingState(this.config, this.state, this.hass);
         this.secondaryInfo = getSecondaryInfo(this.config, this.hass, isCharging);

--- a/src/sorting.ts
+++ b/src/sorting.ts
@@ -25,10 +25,9 @@ import { isNumber, log, safeGetConfigArrayOfObjects, toNumber } from "./utils";
                     valB = batteries[idB].name;
                     break;
                 case "state":
-                    // not a perfect solution but we try to fix numer formatting in some countries/langs
-                    // where decimals are separated by comma
-                    valA = batteries[idA].state?.replace(",", ".");
-                    valB = batteries[idB].state?.replace(",", ".");
+                    // always prefer numeric state for sorting
+                    valA = batteries[idA].stateNumeric == undefined ? batteries[idA].state : batteries[idA].stateNumeric;
+                    valB = batteries[idB].stateNumeric == undefined ? batteries[idB].state : batteries[idB].stateNumeric;
                     break;
                 default:
                     if ((<string>o.by).startsWith("entity.")) {

--- a/test/card/sorting.test.ts
+++ b/test/card/sorting.test.ts
@@ -33,7 +33,7 @@ describe("Entities correctly sorted", () => {
 
     test.each([
         ["state", ["50%", "90%", "40%"], "40 %, 50 %, 90 %"],
-    ])("when HA state formatting returns various results", async (sort: ISimplifiedArray<ISortOption>, formattedStates: string[], expectedOrder: string) => {
+    ])("when HA state formatting returns various result formats", async (sort: ISimplifiedArray<ISortOption>, formattedStates: string[], expectedOrder: string) => {
 
         const hass = new HomeAssistantMock<BatteryStateCard>();
         const entities = formattedStates.map((state, i) => {

--- a/test/card/sorting.test.ts
+++ b/test/card/sorting.test.ts
@@ -2,11 +2,11 @@ import { BatteryStateCard } from "../../src/custom-elements/battery-state-card";
 import { CardElements, HomeAssistantMock } from "../helpers";
 
 
-describe("Sorting", () => {
+describe("Entities correctly sorted", () => {
     test.each([
         ["state", ["50", "90", "40"], "40 %, 50 %, 90 %"],
         ["state", ["40.5", "40.9", "40", "40.4"], "40 %, 40,4 %, 40,5 %, 40,9 %"],
-    ])("Items correctly sorted", async (sort: ISimplifiedArray<ISortOption>, entityStates: string[], expectedOrder: string) => {
+    ])("when various state values appear", async (sort: ISimplifiedArray<ISortOption>, entityStates: string[], expectedOrder: string) => {
 
         const hass = new HomeAssistantMock<BatteryStateCard>();
         const entities = entityStates.map((state, i) => {
@@ -20,6 +20,82 @@ describe("Sorting", () => {
             title: "Header",
             entities,
             sort
+        });
+
+        // waiting for card to be updated/rendered
+        await cardElem.cardUpdated;
+
+        const card = new CardElements(cardElem);
+
+        const result = card.items.map(e => e.stateText).join(", ");
+        expect(result).toBe(expectedOrder);
+    });
+
+    test.each([
+        ["state", ["50%", "90%", "40%"], "40 %, 50 %, 90 %"],
+    ])("when HA state formatting returns various results", async (sort: ISimplifiedArray<ISortOption>, formattedStates: string[], expectedOrder: string) => {
+
+        const hass = new HomeAssistantMock<BatteryStateCard>();
+        const entities = formattedStates.map((state, i) => {
+            const batt = hass.addEntity(`Batt ${i + 1}`, "10");
+            return batt.entity_id;
+        });
+
+        let i = 0;
+        hass.mockFunc("formatEntityState", (entityData: any) => formattedStates[i++]);
+
+        const cardElem = hass.addCard("battery-state-card", {
+            title: "Header",
+            entities,
+            sort
+        });
+
+        // waiting for card to be updated/rendered
+        await cardElem.cardUpdated;
+
+        const card = new CardElements(cardElem);
+
+        const result = card.items.map(e => e.stateText).join(", ");
+        expect(result).toBe(expectedOrder);
+    });
+
+    test.each([
+        ["state", ["good", "low", "empty", "full"], "Empty, Low, Good, Full"],
+        ["state", ["good", "low", "unknown", "empty", "full"], "Unknown, Empty, Low, Good, Full"],
+    ])("when state_map is used with display value", async (sort: ISimplifiedArray<ISortOption>, formattedStates: string[], expectedOrder: string) => {
+
+        const hass = new HomeAssistantMock<BatteryStateCard>();
+        const entities = formattedStates.map((state, i) => {
+            const batt = hass.addEntity(`Batt ${i + 1}`, state);
+            return batt.entity_id;
+        });
+
+        const cardElem = hass.addCard("battery-state-card", <any>{
+            title: "Header",
+            entities,
+            sort,
+            state_map: [
+                {
+                    from: "empty",
+                    to: "0",
+                    display: "Empty"
+                },
+                {
+                    from: "low",
+                    to: "1",
+                    display: "Low"
+                },
+                {
+                    from: "good",
+                    to: "2",
+                    display: "Good"
+                },
+                {
+                    from: "full",
+                    to: "3",
+                    display: "Full"
+                },
+            ]
         });
 
         // waiting for card to be updated/rendered


### PR DESCRIPTION
Currently when the state_map is used with display value we ignore the numeric value which is being set and always sort via the rendered state. 

#668 