### PR TITLE
Added a setting to allow showing hidden entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ These options can be specified both per-entity and at the top level (affecting a
 | non_battery_entity | boolean | `false` | v3.0.0 | Disables default battery state sources e.g. "battery_level" attribute
 | default_state_formatting | boolean | `true` | v3.1.0 | Can be used to disable default state formatting e.g. entity display precission setting
 | debug | boolean \| string | `false` | v3.2.0 | Whether to show debug output (all available entity data). You can use entity_id if you want to debug specific one.
+| respect_visibility_setting | boolean | `true` | v3.3.0 | Whether to hide entities which are marked in the UI as hidden on dashboards.
 
 ### Keyword string (KString)
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ This is a string value containing dynamic values. Data for dynamic values can be
 | Type | Example | Description |
 |:-----|:-----|:-----|
 | Charging state | `"{charging}"` | Shows text specified in [ChargingState](#charging-state-object)
-| Entity property | `"{last_updated}"` | Current entity property. To show relative time there cannot be any additional string befor/after the keyword otherwise it will show full date.
+| Entity property | `"{last_updated}"` | Current entity property. To ensure relative time, use the reltime() function via "\|" (see below). E.g.: `"Changed: {last_updated\|reltime()}"`
 | Entity attributes | `"Remaining time: {attributes.remaining_time}"` | Current entity attribute value.
 | Other entity data | `"Since last charge: {sensor.tesla.attributes.distance}"` | You can use full "path" to the other entity data
 

--- a/README.md
+++ b/README.md
@@ -106,8 +106,8 @@ These options can be specified both per-entity and at the top level (affecting a
 | unit | string | `"%"` | v2.1.0 | Override for unit displayed next to the state/level value ([example](#other-use-cases))
 | value_override | [KString](#keyword-string-kstring) |  | v3.0.0 | Allows to override the battery level value. Note: when used the `multiplier`, `round`, `state_map` setting is ignored
 | non_battery_entity | boolean | `false` | v3.0.0 | Disables default battery state sources e.g. "battery_level" attribute
-| default_state_formatting | bollean | `true` | v3.1.0 | Can be used to disable default state formatting e.g. entity display precission setting
-| debug | boolean \| string | `false` | v3.2.0 | Whether to show debug otuput (all available entity data). You can use entity_id if you want to debug specific one.
+| default_state_formatting | boolean | `true` | v3.1.0 | Can be used to disable default state formatting e.g. entity display precission setting
+| debug | boolean \| string | `false` | v3.2.0 | Whether to show debug output (all available entity data). You can use entity_id if you want to debug specific one.
 
 ### Keyword string (KString)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "battery-state-card",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "Battery State card for Home Assistant",
   "main": "dist/battery-state-card.js",
   "author": "Max Chodorowski",

--- a/src/battery-provider.ts
+++ b/src/battery-provider.ts
@@ -15,8 +15,9 @@ const entititesGlobalProps: (keyof IBatteryEntityConfig)[] = [
     "default_state_formatting",
     "extend_entity_data",
     "icon", 
-    "non_battery_entity", 
-    "round",  
+    "non_battery_entity",
+    "respect_visibility_setting",
+    "round",
     "secondary_info", 
     "state_map", 
     "tap_action", 
@@ -217,11 +218,6 @@ export class BatteryProvider {
      */
     private processExcludes() {
         if (this.exclude == undefined) {
-            Object.keys(this.batteries).forEach((entityId) => {
-                const battery = this.batteries[entityId];
-                battery.isHidden = (<EntityRegistryDisplayEntry>battery.entityData?.display)?.hidden;
-            });
-
             return;
         }
 
@@ -248,8 +244,8 @@ export class BatteryProvider {
             }
 
             // we keep the view model to keep updating it
-            // it might be shown/not-hidden next time
-            battery.isHidden = isHidden || (<EntityRegistryDisplayEntry>battery.entityData?.display)?.hidden;
+            // it might be shown/not-hidden after next update
+            isHidden? battery.hideEntity() : battery.showEntity();
         });
 
         toBeRemoved.forEach(entityId => delete this.batteries[entityId]);
@@ -262,5 +258,4 @@ export interface IBatteryCollection {
 
 export interface IBatteryCollectionItem extends BatteryStateEntity {
     entityId?: string;
-    isHidden?: boolean;
 }

--- a/src/custom-elements/battery-state-entity.ts
+++ b/src/custom-elements/battery-state-entity.ts
@@ -12,7 +12,7 @@ import { getChargingState } from "../entity-fields/charging-state";
 import { getBatteryLevel } from "../entity-fields/battery-level";
 import { getName } from "../entity-fields/get-name";
 import { getIcon } from "../entity-fields/get-icon";
-import { DeviceRegistryEntry } from "../type-extensions";
+import { DeviceRegistryEntry, EntityRegistryDisplayEntry } from "../type-extensions";
 
 /**
  * Battery entity element
@@ -62,6 +62,11 @@ export class BatteryStateEntity extends LovelaceCard<IBatteryEntityConfig> {
     public action: IAction | undefined;
 
     /**
+     * Whether entity should not be shown
+     */
+    public isHidden: boolean | undefined;
+
+    /**
      * Raw entity data
      */
     public entityData: IMap<any> = {};
@@ -85,6 +90,9 @@ export class BatteryStateEntity extends LovelaceCard<IBatteryEntityConfig> {
 
         if (this.config.extend_entity_data !== false) {
             this.extendEntityData();
+
+            // make sure entity is visible when it should be shown
+            this.showEntity();
         }
 
         if (this.config.debug === true || this.config.debug === this.config.entity) {
@@ -125,6 +133,20 @@ export class BatteryStateEntity extends LovelaceCard<IBatteryEntityConfig> {
     }
 
     onError(): void {
+    }
+
+    hideEntity(): void {
+        this.isHidden = true;
+    }
+
+    showEntity(): void {
+        if (this.config.respect_visibility_setting !== false && (<EntityRegistryDisplayEntry>this.entityData?.display)?.hidden) {
+            // When entity is marked as hidden in the UI we should respect it
+            this.isHidden = true;
+            return;
+        }
+
+        this.isHidden = false;
     }
 
     /**

--- a/src/custom-elements/lovelace-card.ts
+++ b/src/custom-elements/lovelace-card.ts
@@ -153,7 +153,7 @@ const errorHtml = (cardName: string, message: string, content: string | undefine
     <ol>
         <li>
             Please check if the problem was reported already<br />
-            Click <a target="_blank" href="https://github.com/maxwroc/battery-state-card/issues?q=is%3Aissue+is%3Aopen+${encodeURIComponent(message)}">here</a> to search
+            Click <a target="_blank" href="https://github.com/maxwroc/battery-state-card/issues?q=is%3Aissue+${encodeURIComponent(message)}">here</a> to search
         </li>
         <li>
             If it wasn't please consider creating one<br />

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -264,6 +264,11 @@ interface IBatteryEntityConfig {
      * Whether to print the debug output
      */
     debug?: string | boolean,
+
+    /**
+     * Whether to respect HA entity visibility setting
+     */
+    respect_visibility_setting?: boolean,
 }
 
 interface IBatteryCardConfig {

--- a/test/card/filters.test.ts
+++ b/test/card/filters.test.ts
@@ -67,15 +67,19 @@ test("Include via entity_id and exclude via state - empty result", async () => {
 
 
 test.each([
-    [false, 1],
-    [true, 0],
-])("Entity filtered based on hidden state", async (isHidden: boolean, numOfRenderedEntities: number) => {
+    [false, undefined, 1],
+    [true, undefined, 0],
+    [false, true, 1],
+    [true, true, 0],
+    [false, false, 1],
+    [true, false, 1],
+])("Entity filtered based on hidden state", async (isHidden: boolean, respectVisibilitySetting: boolean | undefined, numOfRenderedEntities: number) => {
 
     const hass = new HomeAssistantMock<BatteryStateCard>();
     const entity = hass.addEntity("Bedroom motion battery level", "90");
     entity.setProperty("display", { entity_id: "", hidden: isHidden })
 
-    const cardElem = hass.addCard("battery-state-card", {
+    const cardElem = hass.addCard("battery-state-card", <any>{
         title: "Header",
         filter: {
             include: [
@@ -86,7 +90,8 @@ test.each([
             ],
             exclude: [],
         },
-        entities: []
+        entities: [],
+        respect_visibility_setting: respectVisibilitySetting,
     });
 
     // waiting for card to be updated/rendered


### PR DESCRIPTION
#690 

The `respect_visibility_setting: false` will now allow showing entities which are marked as hidden in the UI