### PR TITLE
Support KString in the actions data

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,12 +303,48 @@ The definition is similar to the default [tap-action](https://www.home-assistant
 | Name | Type | Default | Description |
 |:-----|:-----|:-----|:-----|
 | action | string | `more-info` | Action type, one of the following: `more-info`, `call-service`, `navigate`, `url`, `none`
-| service | string |  | Service to call when `action` defined as `call-service`. Eg. `"notify.pushover"`
-| service_data | any |  | Service data to inlclue when `action` defined as `call-service`
-| navigation_path | string |  | Path to navigate to when `action` defined as `navigate`. Eg. `"/lovelace/0"`
-| url_path | string |  | Url to navigate to when `action` defined as `url`. Eg. `"https://www.home-assistant.io"`
+| service | [KString](#keyword-string-kstring) \| string |  | Service to call when `action` defined as `call-service`. Eg. `"notify.pushover"`. Supports KString for dynamic values.
+| service_data | any |  | Service data to include when `action` defined as `call-service`. Supports KString in nested string values.
+| data | any |  | Additional data for the action. Supports KString in nested string values.
+| target | any |  | Target for the service call. Supports KString in nested string values.
+| navigation_path | [KString](#keyword-string-kstring) \| string |  | Path to navigate to when `action` defined as `navigate`. Eg. `"/lovelace/0"`. Supports KString for dynamic values.
+| url_path | [KString](#keyword-string-kstring) \| string |  | Url to navigate to when `action` defined as `url`. Eg. `"https://www.home-assistant.io"`. Supports KString for dynamic values.
 
 Note: From version 3.3.0 card supports all native Home Assistant actions and related functionalities: [Actions - Home Assistant](https://www.home-assistant.io/dashboards/actions/#tap-action)
+
+**KString support in actions:** Since v3.3.0, tap actions support [KString](#keyword-string-kstring) for dynamic values. This allows you to use entity data (state, attributes, etc.) in action parameters. KString processing happens just before the action is executed, ensuring up-to-date values.
+
+**Examples:**
+```yaml
+# Navigate to device page using device_id from entity attributes
+tap_action:
+  action: navigate
+  navigation_path: /config/devices/device/{attributes.device_id}
+
+# Open URL with dynamic content
+tap_action:
+  action: url
+  url_path: https://example.com/battery-report?level={state}&device={attributes.device_name}
+
+# Call service with dynamic data
+tap_action:
+  action: call-service
+  service: notify.mobile_app
+  service_data:
+    message: "Low battery alert: {state}%"
+    title: "Warning for {attributes.friendly_name}"
+    data:
+      entity_id: "{entity_id}"
+      battery_level: "{state}"
+
+# Use KString functions in actions
+tap_action:
+  action: call-service
+  service: script.battery_notification
+  data:
+    rounded_level: "{state|round(0)}"
+    doubled_value: "{state|multiply(2)|round(1)}"
+```
 
 ### Convert
 

--- a/src/custom-elements/battery-state-entity.ts
+++ b/src/custom-elements/battery-state-entity.ts
@@ -179,6 +179,8 @@ export class BatteryStateEntity extends LovelaceCard<IBatteryEntityConfig> {
                             tap_action: safeGetConfigObject(tapAction!, "action"),
                         },
                         "tap",
+                        this.hass,
+                        this.entityData,
                     );
                 }
 

--- a/src/handle-action.ts
+++ b/src/handle-action.ts
@@ -1,3 +1,6 @@
+import { HomeAssistant } from "custom-card-helpers";
+import { RichStringProcessor } from "./rich-string-processor";
+
 /**
  * Action configuration parameters
  */
@@ -14,13 +17,111 @@ export type ActionConfigParams = {
  * @param node Element to fire event on
  * @param config Action configuration
  * @param action Action type (tap, hold, double_tap)
+ * @param hass Home Assistant instance
+ * @param entityData Entity data for KString processing
  */
 export const handleAction = async (
   node: HTMLElement,
   config: ActionConfigParams,
   action: string,
+  hass?: HomeAssistant,
+  entityData?: IMap<any>,
 ): Promise<void> => {
+  // Process KString values in action config if hass is provided
+  if (hass) {
+    config = processActionConfig(config, hass, entityData);
+  }
+
   fireEvent(node, "hass-action", { config, action });
+};
+
+/**
+ * Process KString values in action configuration
+ * @param config Action configuration to process
+ * @param hass Home Assistant instance
+ * @param entityData Entity data for KString processing
+ * @returns Processed action configuration
+ */
+const processActionConfig = (
+  config: ActionConfigParams,
+  hass: HomeAssistant,
+  entityData?: IMap<any>,
+): ActionConfigParams => {
+  const processor = new RichStringProcessor(hass, entityData);
+  const processedConfig = { ...config };
+
+  // Process each action type (tap_action, hold_action, double_tap_action)
+  for (const actionType of ['tap_action', 'hold_action', 'double_tap_action'] as const) {
+    const actionConfig = processedConfig[actionType];
+
+    if (actionConfig && typeof actionConfig === 'object') {
+      processedConfig[actionType] = processActionProperties(actionConfig, processor);
+    }
+  }
+
+  return processedConfig;
+};
+
+/**
+ * Process KString values in action properties
+ * @param actionConfig Action configuration object
+ * @param processor RichStringProcessor instance
+ * @returns Processed action configuration
+ */
+const processActionProperties = (
+  actionConfig: Extract<NativeHomeAssistantActionConfig, { action: string }>,
+  processor: RichStringProcessor,
+): NativeHomeAssistantActionConfig => {
+  const processed = { ...actionConfig } as any;
+
+  // Process string properties that may contain KString
+  const stringProperties = ['navigation_path', 'url_path', 'service'] as const;
+  for (const prop of stringProperties) {
+    if (processed[prop] && typeof processed[prop] === 'string') {
+      processed[prop] = processor.process(processed[prop]);
+    }
+  }
+
+  // Process nested objects (service_data, data, target)
+  const objectProperties = ['service_data', 'data', 'target'] as const;
+  for (const prop of objectProperties) {
+    if (processed[prop]) {
+      processed[prop] = processObjectRecursively(processed[prop], processor);
+    }
+  }
+
+  return processed;
+};
+
+/**
+ * Recursively process KString values in an object
+ * @param obj Object to process
+ * @param processor RichStringProcessor instance
+ * @returns Processed object
+ */
+const processObjectRecursively = (
+  obj: any,
+  processor: RichStringProcessor,
+): any => {
+  if (typeof obj === 'string') {
+    return processor.process(obj);
+  }
+
+  if (Array.isArray(obj)) {
+    return obj.map(item => processObjectRecursively(item, processor));
+  }
+
+  if (obj && typeof obj === 'object') {
+    const processed: any = {};
+    for (const key in obj) {
+      if (obj.hasOwnProperty(key)) {
+        processed[key] = processObjectRecursively(obj[key], processor);
+      }
+    }
+    return processed;
+  }
+
+  return obj;
 };
 
 /**

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -39,6 +39,13 @@ interface IColorSettings {
  */
 type NativeHomeAssistantActionConfig = {
     action: string;
+    navigation_path?: string;
+    url_path?: string;
+    service?: string;
+    service_data?: any;
+    data?: any;
+    target?: any;
+    confirmation?: any;
 } | string;
 
 /**

--- a/test/integration/entity/actions.test.ts
+++ b/test/integration/entity/actions.test.ts
@@ -1,0 +1,214 @@
+import { expect } from '@esm-bundle/chai';
+import { BatteryStateEntity } from "../../../src/custom-elements/battery-state-entity";
+import { HomeAssistantMock } from "../../helpers";
+
+it("tap_action processes KString in navigation_path", async () => {
+    const hass = new HomeAssistantMock<BatteryStateEntity>();
+    const sensor = hass.addEntity("Battery Sensor", "50", { device_id: "device123" }, "sensor");
+
+    let firedEvent: any = null;
+
+    const cardElem = hass.addCard("battery-state-entity", {
+        entity: sensor.entity_id,
+        tap_action: {
+            action: "navigate",
+            navigation_path: "/config/devices/device/{attributes.device_id}"
+        }
+    });
+
+    await cardElem.cardUpdated;
+
+    // Listen for the hass-action event
+    cardElem.addEventListener("hass-action", (e: any) => {
+        firedEvent = e;
+    });
+
+    // Simulate a click
+    cardElem.click();
+
+    expect(firedEvent).to.not.be.null;
+    expect(firedEvent.detail.action).to.equal("tap");
+    expect(firedEvent.detail.config.tap_action.navigation_path).to.equal("/config/devices/device/device123");
+});
+
+it("tap_action processes KString in service_data with nested values", async () => {
+    const hass = new HomeAssistantMock<BatteryStateEntity>();
+    const sensor = hass.addEntity("Battery Sensor", "25", { device_name: "Bedroom Sensor" }, "sensor");
+
+    let firedEvent: any = null;
+
+    const cardElem = hass.addCard("battery-state-entity", {
+        entity: sensor.entity_id,
+        tap_action: {
+            action: "call-service",
+            service: "notify.mobile_app",
+            service_data: {
+                message: "Low battery: {state}%",
+                title: "Alert for {attributes.device_name}",
+                data: {
+                    entity_id: "{entity_id}",
+                    battery_level: "{state}"
+                }
+            }
+        }
+    });
+
+    await cardElem.cardUpdated;
+
+    // Listen for the hass-action event
+    cardElem.addEventListener("hass-action", (e: any) => {
+        firedEvent = e;
+    });
+
+    // Simulate a click
+    cardElem.click();
+
+    expect(firedEvent).to.not.be.null;
+    expect(firedEvent.detail.config.tap_action.service_data.message).to.equal("Low battery: 25%");
+    expect(firedEvent.detail.config.tap_action.service_data.title).to.equal("Alert for Bedroom Sensor");
+    expect(firedEvent.detail.config.tap_action.service_data.data.entity_id).to.equal(sensor.entity_id);
+    expect(firedEvent.detail.config.tap_action.service_data.data.battery_level).to.equal("25");
+});
+
+it("tap_action processes KString with external entity reference", async () => {
+    const hass = new HomeAssistantMock<BatteryStateEntity>();
+    const sensor = hass.addEntity("Battery Sensor", "50", {}, "sensor");
+    const deviceTracker = hass.addEntity("Phone Location", "home", {}, "device_tracker");
+
+    let firedEvent: any = null;
+
+    const cardElem = hass.addCard("battery-state-entity", {
+        entity: sensor.entity_id,
+        tap_action: {
+            action: "navigate",
+            navigation_path: "/map/{device_tracker.phone_location.state}"
+        }
+    });
+
+    await cardElem.cardUpdated;
+
+    // Listen for the hass-action event
+    cardElem.addEventListener("hass-action", (e: any) => {
+        firedEvent = e;
+    });
+
+    // Simulate a click
+    cardElem.click();
+
+    expect(firedEvent).to.not.be.null;
+    expect(firedEvent.detail.config.tap_action.navigation_path).to.equal("/map/home");
+});
+
+it("tap_action processes KString with processing functions", async () => {
+    const hass = new HomeAssistantMock<BatteryStateEntity>();
+    const sensor = hass.addEntity("Battery Sensor", "50.789", {}, "sensor");
+
+    let firedEvent: any = null;
+
+    const cardElem = hass.addCard("battery-state-entity", {
+        entity: sensor.entity_id,
+        tap_action: {
+            action: "call-service",
+            service: "notify.notify",
+            service_data: {
+                message: "Battery: {state|round(0)}%",
+                title: "Doubled: {state|multiply(2)|round(1)}"
+            }
+        }
+    });
+
+    await cardElem.cardUpdated;
+
+    // Listen for the hass-action event
+    cardElem.addEventListener("hass-action", (e: any) => {
+        firedEvent = e;
+    });
+
+    // Simulate a click
+    cardElem.click();
+
+    expect(firedEvent).to.not.be.null;
+    expect(firedEvent.detail.config.tap_action.service_data.message).to.equal("Battery: 51%");
+    expect(firedEvent.detail.config.tap_action.service_data.title).to.equal("Doubled: 101.6");
+});
+
+it("tap_action with 'more-info' string action works correctly", async () => {
+    const hass = new HomeAssistantMock<BatteryStateEntity>();
+    const sensor = hass.addEntity("Battery Sensor", "50", {}, "sensor");
+
+    let firedEvent: any = null;
+
+    const cardElem = hass.addCard("battery-state-entity", {
+        entity: sensor.entity_id,
+        tap_action: "more-info"
+    });
+
+    await cardElem.cardUpdated;
+
+    // Listen for the hass-action event
+    cardElem.addEventListener("hass-action", (e: any) => {
+        firedEvent = e;
+    });
+
+    // Simulate a click
+    cardElem.click();
+
+    expect(firedEvent).to.not.be.null;
+    // safeGetConfigObject converts string to object { action: "more-info" }
+    expect(firedEvent.detail.config.tap_action).to.deep.equal({ action: "more-info" });
+});
+
+it("tap_action processes url_path with KString", async () => {
+    const hass = new HomeAssistantMock<BatteryStateEntity>();
+    const sensor = hass.addEntity("Battery Sensor", "50", { device_model: "XYZ-2000" }, "sensor");
+
+    let firedEvent: any = null;
+
+    const cardElem = hass.addCard("battery-state-entity", {
+        entity: sensor.entity_id,
+        tap_action: {
+            action: "url",
+            url_path: "https://example.com/manual/{attributes.device_model}"
+        }
+    });
+
+    await cardElem.cardUpdated;
+
+    // Listen for the hass-action event
+    cardElem.addEventListener("hass-action", (e: any) => {
+        firedEvent = e;
+    });
+
+    // Simulate a click
+    cardElem.click();
+
+    expect(firedEvent).to.not.be.null;
+    expect(firedEvent.detail.config.tap_action.url_path).to.equal("https://example.com/manual/XYZ-2000");
+});
+
+it("entity with no tap_action (default more-info) should not break", async () => {
+    const hass = new HomeAssistantMock<BatteryStateEntity>();
+    const sensor = hass.addEntity("Battery Sensor", "50", { device_id: "abc123" }, "sensor");
+
+    let firedEvent: any = null;
+
+    const cardElem = hass.addCard("battery-state-entity", {
+        entity: sensor.entity_id
+        // No tap_action specified, should default to "more-info"
+    });
+
+    await cardElem.cardUpdated;
+
+    // Listen for the hass-action event
+    cardElem.addEventListener("hass-action", (e: any) => {
+        firedEvent = e;
+    });
+
+    // Simulate a click
+    cardElem.click();
+
+    expect(firedEvent).to.not.be.null;
+    expect(firedEvent.detail.action).to.equal("tap");
+    // safeGetConfigObject converts string to object { action: "more-info" }
+    expect(firedEvent.detail.config.tap_action).to.deep.equal({ action: "more-info" });
+});

--- a/test/unit/handle-action.test.ts
+++ b/test/unit/handle-action.test.ts
@@ -1,0 +1,432 @@
+import { handleAction } from "../../src/handle-action";
+import { HomeAssistantMock } from "../helpers";
+import { BatteryStateEntity } from "../../src/custom-elements/battery-state-entity";
+
+describe("handleAction", () => {
+
+    describe("KString processing in action config", () => {
+
+        test("processes navigation_path with entity attributes", () => {
+            const hassMock = new HomeAssistantMock<BatteryStateEntity>(true);
+            const sensor = hassMock.addEntity("Battery Sensor", "50", { device_id: "abc123" }, "sensor");
+            const entityData = hassMock.hass.states[sensor.entity_id];
+
+            const node = document.createElement("div");
+            let firedEvent: any = null;
+            node.addEventListener("hass-action", (e) => {
+                firedEvent = e;
+            });
+
+            handleAction(
+                node,
+                {
+                    entity: sensor.entity_id,
+                    tap_action: {
+                        action: "navigate",
+                        navigation_path: "/config/devices/device/{attributes.device_id}"
+                    }
+                },
+                "tap",
+                hassMock.hass,
+                entityData
+            );
+
+            expect(firedEvent).not.toBeNull();
+            expect(firedEvent.detail.config.tap_action.navigation_path).toBe("/config/devices/device/abc123");
+        });
+
+        test("processes navigation_path with entity state", () => {
+            const hassMock = new HomeAssistantMock<BatteryStateEntity>(true);
+            const sensor = hassMock.addEntity("Battery Sensor", "50", {}, "sensor");
+            const entityData = hassMock.hass.states[sensor.entity_id];
+
+            const node = document.createElement("div");
+            let firedEvent: any = null;
+            node.addEventListener("hass-action", (e) => {
+                firedEvent = e;
+            });
+
+            handleAction(
+                node,
+                {
+                    entity: sensor.entity_id,
+                    tap_action: {
+                        action: "navigate",
+                        navigation_path: "/lovelace/battery-{state}"
+                    }
+                },
+                "tap",
+                hassMock.hass,
+                entityData
+            );
+
+            expect(firedEvent).not.toBeNull();
+            expect(firedEvent.detail.config.tap_action.navigation_path).toBe("/lovelace/battery-50");
+        });
+
+        test("processes url_path with KString", () => {
+            const hassMock = new HomeAssistantMock<BatteryStateEntity>(true);
+            const sensor = hassMock.addEntity("Battery Sensor", "50", { device_name: "MyDevice" }, "sensor");
+            const entityData = hassMock.hass.states[sensor.entity_id];
+
+            const node = document.createElement("div");
+            let firedEvent: any = null;
+            node.addEventListener("hass-action", (e) => {
+                firedEvent = e;
+            });
+
+            handleAction(
+                node,
+                {
+                    entity: sensor.entity_id,
+                    tap_action: {
+                        action: "url",
+                        url_path: "https://example.com/device/{attributes.device_name}"
+                    }
+                },
+                "tap",
+                hassMock.hass,
+                entityData
+            );
+
+            expect(firedEvent).not.toBeNull();
+            expect(firedEvent.detail.config.tap_action.url_path).toBe("https://example.com/device/MyDevice");
+        });
+
+        test("processes service name with KString", () => {
+            const hassMock = new HomeAssistantMock<BatteryStateEntity>(true);
+            const sensor = hassMock.addEntity("Battery Sensor", "on", {}, "sensor");
+            const entityData = hassMock.hass.states[sensor.entity_id];
+
+            const node = document.createElement("div");
+            let firedEvent: any = null;
+            node.addEventListener("hass-action", (e) => {
+                firedEvent = e;
+            });
+
+            handleAction(
+                node,
+                {
+                    entity: sensor.entity_id,
+                    tap_action: {
+                        action: "call-service",
+                        service: "light.turn_{state}"
+                    }
+                },
+                "tap",
+                hassMock.hass,
+                entityData
+            );
+
+            expect(firedEvent).not.toBeNull();
+            expect(firedEvent.detail.config.tap_action.service).toBe("light.turn_on");
+        });
+
+        test("processes service_data with KString in nested values", () => {
+            const hassMock = new HomeAssistantMock<BatteryStateEntity>(true);
+            const sensor = hassMock.addEntity("Battery Sensor", "50", { device_id: "abc123" }, "sensor");
+            const entityData = hassMock.hass.states[sensor.entity_id];
+
+            const node = document.createElement("div");
+            let firedEvent: any = null;
+            node.addEventListener("hass-action", (e) => {
+                firedEvent = e;
+            });
+
+            handleAction(
+                node,
+                {
+                    entity: sensor.entity_id,
+                    tap_action: {
+                        action: "call-service",
+                        service: "notify.notify",
+                        service_data: {
+                            message: "Battery level is {state}%",
+                            title: "Device {attributes.device_id}",
+                            data: {
+                                device: "{attributes.device_id}"
+                            }
+                        }
+                    }
+                },
+                "tap",
+                hassMock.hass,
+                entityData
+            );
+
+            expect(firedEvent).not.toBeNull();
+            expect(firedEvent.detail.config.tap_action.service_data.message).toBe("Battery level is 50%");
+            expect(firedEvent.detail.config.tap_action.service_data.title).toBe("Device abc123");
+            expect(firedEvent.detail.config.tap_action.service_data.data.device).toBe("abc123");
+        });
+
+        test("processes data field with KString", () => {
+            const hassMock = new HomeAssistantMock<BatteryStateEntity>(true);
+            const sensor = hassMock.addEntity("Battery Sensor", "25", {}, "sensor");
+            const entityData = hassMock.hass.states[sensor.entity_id];
+
+            const node = document.createElement("div");
+            let firedEvent: any = null;
+            node.addEventListener("hass-action", (e) => {
+                firedEvent = e;
+            });
+
+            handleAction(
+                node,
+                {
+                    entity: sensor.entity_id,
+                    tap_action: {
+                        action: "call-service",
+                        service: "script.battery_alert",
+                        data: {
+                            battery_level: "{state}"
+                        }
+                    }
+                },
+                "tap",
+                hassMock.hass,
+                entityData
+            );
+
+            expect(firedEvent).not.toBeNull();
+            expect(firedEvent.detail.config.tap_action.data.battery_level).toBe("25");
+        });
+
+        test("processes target field with KString", () => {
+            const hassMock = new HomeAssistantMock<BatteryStateEntity>(true);
+            const sensor = hassMock.addEntity("Battery Sensor", "50", { target_entity: "light.bedroom" }, "sensor");
+            const entityData = hassMock.hass.states[sensor.entity_id];
+
+            const node = document.createElement("div");
+            let firedEvent: any = null;
+            node.addEventListener("hass-action", (e) => {
+                firedEvent = e;
+            });
+
+            handleAction(
+                node,
+                {
+                    entity: sensor.entity_id,
+                    tap_action: {
+                        action: "call-service",
+                        service: "light.turn_on",
+                        target: {
+                            entity_id: "{attributes.target_entity}"
+                        }
+                    }
+                },
+                "tap",
+                hassMock.hass,
+                entityData
+            );
+
+            expect(firedEvent).not.toBeNull();
+            expect(firedEvent.detail.config.tap_action.target.entity_id).toBe("light.bedroom");
+        });
+
+        test("processes array values in service_data", () => {
+            const hassMock = new HomeAssistantMock<BatteryStateEntity>(true);
+            const sensor = hassMock.addEntity("Battery Sensor", "50", {}, "sensor");
+            const entityData = hassMock.hass.states[sensor.entity_id];
+
+            const node = document.createElement("div");
+            let firedEvent: any = null;
+            node.addEventListener("hass-action", (e) => {
+                firedEvent = e;
+            });
+
+            handleAction(
+                node,
+                {
+                    entity: sensor.entity_id,
+                    tap_action: {
+                        action: "call-service",
+                        service: "script.run",
+                        service_data: {
+                            values: ["Battery: {state}%", "Entity: {entity_id}"]
+                        }
+                    }
+                },
+                "tap",
+                hassMock.hass,
+                entityData
+            );
+
+            expect(firedEvent).not.toBeNull();
+            expect(firedEvent.detail.config.tap_action.service_data.values[0]).toBe("Battery: 50%");
+            expect(firedEvent.detail.config.tap_action.service_data.values[1]).toBe("Entity: " + sensor.entity_id);
+        });
+
+        test("processes hold_action with KString", () => {
+            const hassMock = new HomeAssistantMock<BatteryStateEntity>(true);
+            const sensor = hassMock.addEntity("Battery Sensor", "50", { device_id: "xyz789" }, "sensor");
+            const entityData = hassMock.hass.states[sensor.entity_id];
+
+            const node = document.createElement("div");
+            let firedEvent: any = null;
+            node.addEventListener("hass-action", (e) => {
+                firedEvent = e;
+            });
+
+            handleAction(
+                node,
+                {
+                    entity: sensor.entity_id,
+                    hold_action: {
+                        action: "navigate",
+                        navigation_path: "/device/{attributes.device_id}"
+                    }
+                },
+                "hold",
+                hassMock.hass,
+                entityData
+            );
+
+            expect(firedEvent).not.toBeNull();
+            expect(firedEvent.detail.config.hold_action.navigation_path).toBe("/device/xyz789");
+        });
+
+        test("processes double_tap_action with KString", () => {
+            const hassMock = new HomeAssistantMock<BatteryStateEntity>(true);
+            const sensor = hassMock.addEntity("Battery Sensor", "50", { device_id: "xyz789" }, "sensor");
+            const entityData = hassMock.hass.states[sensor.entity_id];
+
+            const node = document.createElement("div");
+            let firedEvent: any = null;
+            node.addEventListener("hass-action", (e) => {
+                firedEvent = e;
+            });
+
+            handleAction(
+                node,
+                {
+                    entity: sensor.entity_id,
+                    double_tap_action: {
+                        action: "navigate",
+                        navigation_path: "/info/{attributes.device_id}"
+                    }
+                },
+                "double_tap",
+                hassMock.hass,
+                entityData
+            );
+
+            expect(firedEvent).not.toBeNull();
+            expect(firedEvent.detail.config.double_tap_action.navigation_path).toBe("/info/xyz789");
+        });
+
+        test("does not process when hass is not provided", () => {
+            const node = document.createElement("div");
+            let firedEvent: any = null;
+            node.addEventListener("hass-action", (e) => {
+                firedEvent = e;
+            });
+
+            handleAction(
+                node,
+                {
+                    entity: "sensor.battery",
+                    tap_action: {
+                        action: "navigate",
+                        navigation_path: "/device/{attributes.device_id}"
+                    }
+                },
+                "tap"
+                // No hass parameter
+            );
+
+            expect(firedEvent).not.toBeNull();
+            // Should keep the original KString pattern
+            expect(firedEvent.detail.config.tap_action.navigation_path).toBe("/device/{attributes.device_id}");
+        });
+
+        test("handles string action config without processing", () => {
+            const hassMock = new HomeAssistantMock<BatteryStateEntity>(true);
+            const sensor = hassMock.addEntity("Battery Sensor", "50", {}, "sensor");
+            const entityData = hassMock.hass.states[sensor.entity_id];
+
+            const node = document.createElement("div");
+            let firedEvent: any = null;
+            node.addEventListener("hass-action", (e) => {
+                firedEvent = e;
+            });
+
+            handleAction(
+                node,
+                {
+                    entity: sensor.entity_id,
+                    tap_action: "more-info" // String action, not an object
+                },
+                "tap",
+                hassMock.hass,
+                entityData
+            );
+
+            expect(firedEvent).not.toBeNull();
+            // String actions stay as strings since processActionProperties only processes objects
+            expect(firedEvent.detail.config.tap_action).toBe("more-info");
+        });
+
+        test("processes KString with external entity reference", () => {
+            const hassMock = new HomeAssistantMock<BatteryStateEntity>(true);
+            const sensor = hassMock.addEntity("Battery Sensor", "50", { device_id: "abc123" }, "sensor");
+            const otherSensor = hassMock.addEntity("Other Sensor", "active", {}, "sensor");
+            const entityData = hassMock.hass.states[sensor.entity_id];
+
+            const node = document.createElement("div");
+            let firedEvent: any = null;
+            node.addEventListener("hass-action", (e) => {
+                firedEvent = e;
+            });
+
+            handleAction(
+                node,
+                {
+                    entity: sensor.entity_id,
+                    tap_action: {
+                        action: "navigate",
+                        navigation_path: "/status/{sensor.other_sensor.state}"
+                    }
+                },
+                "tap",
+                hassMock.hass,
+                entityData
+            );
+
+            expect(firedEvent).not.toBeNull();
+            expect(firedEvent.detail.config.tap_action.navigation_path).toBe("/status/active");
+        });
+
+        test("processes KString with processing functions", () => {
+            const hassMock = new HomeAssistantMock<BatteryStateEntity>(true);
+            const sensor = hassMock.addEntity("Battery Sensor", "50.789", {}, "sensor");
+            const entityData = hassMock.hass.states[sensor.entity_id];
+
+            const node = document.createElement("div");
+            let firedEvent: any = null;
+            node.addEventListener("hass-action", (e) => {
+                firedEvent = e;
+            });
+
+            handleAction(
+                node,
+                {
+                    entity: sensor.entity_id,
+                    tap_action: {
+                        action: "call-service",
+                        service: "notify.notify",
+                        service_data: {
+                            message: "Battery is at {state|round(1)}%"
+                        }
+                    }
+                },
+                "tap",
+                hassMock.hass,
+                entityData
+            );
+
+            expect(firedEvent).not.toBeNull();
+            expect(firedEvent.detail.config.tap_action.service_data.message).toBe("Battery is at 50.8%");
+        });
+    });
+});


### PR DESCRIPTION
#724 

**Examples:**
```yaml
# Navigate to device page using device_id from entity attributes
tap_action:
  action: navigate
  navigation_path: /config/devices/device/{attributes.device_id}
# Open URL with dynamic content
tap_action:
  action: url
  url_path: https://example.com/battery-report?level={state}&device={attributes.device_name}
# Call service with dynamic data
tap_action:
  action: call-service
  service: notify.mobile_app
  service_data:
    message: "Low battery alert: {state}%"
    title: "Warning for {attributes.friendly_name}"
    data:
      entity_id: "{entity_id}"
      battery_level: "{state}"
# Use KString functions in actions
tap_action:
  action: call-service
  service: script.battery_notification
  data:
    rounded_level: "{state|round(0)}"
    doubled_value: "{state|multiply(2)|round(1)}"
```