### PR TITLE
Support custom themes for the card

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ colors:
 | collapse | number \| list([Group](#group-object)) |  | v1.0.0 | Number of entities to show. Rest will be available in expandable section ([example](#sorted-list-and-collapsed-view)). Or list of entity/battery groups ([example](#battery-groups))
 | filter | [Filters](#filters) |  | v1.3.0 | Filter groups to automatically include or exclude entities ([example](#entity-filtering-and-bulk-renaming))
 | bulk_rename | list([Convert](#convert)) \| [BulkRename](#bulk-rename) |  | v1.3.0 | Rename rules applied for all entities ([example](#entity-filtering-and-bulk-renaming))
+| theme | string |  | v3.3.0 | Name of the theme to apply (must be installed in Home Assistant). ([example](#using-themes))
 
 +[common options](#common-options) (if specified they will be apllied to all entities)
 
@@ -771,6 +772,20 @@ entities:
     value_override: 80
 
 ```
+
+### Using Themes
+
+You can apply any Home Assistant theme to the card using the `theme` property. The card will apply the theme's CSS variables to match your Home Assistant theme.
+
+```yaml
+type: custom:battery-state-card
+theme: slate  # Apply the "slate" theme
+entities:
+  - sensor.bedroom_motion_battery_level
+  - sensor.bathroom_motion_battery_level
+```
+
+**Light/Dark Mode Support**: The card automatically detects if your theme has separate light and dark modes and applies the appropriate mode based on Home Assistant's dark mode setting.
 
 ### Other use cases
 

--- a/src/battery-provider.ts
+++ b/src/battery-provider.ts
@@ -194,7 +194,7 @@ export class BatteryProvider {
      * Adds batteries from group entities (if they were on the list)
      * @param hass Home Assistant instance
      */
-    private processGroupEntities(hass: HomeAssistant): void {
+    private processGroupEntities(hass: HomeAssistantExt): void {
         this.groupsToResolve.forEach(group_id => {
             const groupEntity = hass.states[group_id];
             if (!groupEntity) {

--- a/src/custom-elements/battery-state-card.ts
+++ b/src/custom-elements/battery-state-card.ts
@@ -7,7 +7,7 @@ import { getBatteryGroups, IBatteryGroup } from "../grouping";
 import sharedStyles from "./shared.css"
 import cardStyles from "./battery-state-card.css"
 import { getIdsOfSortedBatteries } from "../sorting";
-import { safeGetConfigArrayOfObjects } from "../utils";
+import { safeGetConfigArrayOfObjects, getThemeStyles } from "../utils";
 import defaultConfig from "../default-config";
 
 
@@ -67,6 +67,14 @@ export class BatteryStateCard extends LovelaceCard<IBatteryCardConfig> {
         }
 
         this.header = this.config.title;
+
+        // Apply theme styles directly to host element
+        const themeStyles = getThemeStyles(<any>this.hass, this.config.theme);
+        if (themeStyles) {
+            this.style.cssText = themeStyles;
+        } else {
+            this.style.cssText = "";
+        }
 
         this.batteries = this.batteryProvider.getBatteries();
 

--- a/src/custom-elements/battery-state-entity.views.ts
+++ b/src/custom-elements/battery-state-entity.views.ts
@@ -1,4 +1,4 @@
-import { HomeAssistant } from "custom-card-helpers";
+import { HomeAssistantExt } from "../type-extensions";
 import { TemplateResult, html } from "lit";
 import { BatteryStateEntity } from "./battery-state-entity";
 import { DefaultIcon } from "../entity-fields/get-icon";
@@ -13,7 +13,7 @@ const relativeTimeTag = new RegExp("<rt>([^<]+)</rt>", "g");
  * @param hass HomeAssistant instance
  * @returns Rendered templates
  */
-const replaceTags = (text: string | undefined, hass?: HomeAssistant): TemplateResult[] => {
+const replaceTags = (text: string | undefined, hass?: HomeAssistantExt): TemplateResult[] => {
     if (!text) {
         return [];
     }
@@ -41,7 +41,7 @@ const replaceTags = (text: string | undefined, hass?: HomeAssistant): TemplateRe
     return result;
 }
 
-export const secondaryInfo = (text?: string, hass?: HomeAssistant) => text && html`
+export const secondaryInfo = (text?: string, hass?: HomeAssistantExt) => text && html`
 <div class="secondary">${replaceTags(text, hass)}</div>
 `;
 

--- a/src/entity-fields/charging-state.ts
+++ b/src/entity-fields/charging-state.ts
@@ -1,4 +1,4 @@
-import { HomeAssistant } from "custom-card-helpers/dist/types";
+import { HomeAssistantExt } from "../type-extensions";
 import { log, safeGetArray } from "../utils";
 
 /**
@@ -8,7 +8,7 @@ import { log, safeGetArray } from "../utils";
  * @param hass HomeAssistant state object
  * @returns Whether battery is in chargin mode
  */
- export const getChargingState = (config: IBatteryEntityConfig, state: string, hass: HomeAssistant): boolean => {
+ export const getChargingState = (config: IBatteryEntityConfig, state: string, hass: HomeAssistantExt): boolean => {
     const chargingConfig = config.charging_state;
     if (!chargingConfig) {
         return getDefaultChargingState(config, hass);
@@ -55,7 +55,7 @@ import { log, safeGetArray } from "../utils";
 
 const standardBatteryLevelEntitySuffix = "_battery_level";
 const standardBatteryStateEntitySuffix = "_battery_state";
-const getDefaultChargingState = (config: IBatteryEntityConfig, hass?: HomeAssistant): boolean => {
+const getDefaultChargingState = (config: IBatteryEntityConfig, hass?: HomeAssistantExt): boolean => {
     if (!config.entity.endsWith(standardBatteryLevelEntitySuffix)) {
         return false;
     }

--- a/src/entity-fields/get-icon.ts
+++ b/src/entity-fields/get-icon.ts
@@ -1,4 +1,4 @@
-import { HomeAssistant } from "custom-card-helpers";
+import { HomeAssistantExt } from "../type-extensions";
 import { log } from "../utils";
 import { RichStringProcessor } from "../rich-string-processor";
 
@@ -17,7 +17,7 @@ export const DefaultIcon = "<default_icon>";
  * @param hass HomeAssistant state object
  * @returns Mdi icon string
  */
-export const getIcon = (config: IBatteryEntityConfig, level: number | undefined, isCharging: boolean, hass: HomeAssistant): string => {
+export const getIcon = (config: IBatteryEntityConfig, level: number | undefined, isCharging: boolean, hass: HomeAssistantExt): string => {
     if (isCharging && config.charging_state?.icon) {
         return config.charging_state.icon;
     }

--- a/src/entity-fields/get-name.ts
+++ b/src/entity-fields/get-name.ts
@@ -1,4 +1,4 @@
-import { HomeAssistant } from "custom-card-helpers";
+import { HomeAssistantExt } from "../type-extensions";
 import { getRegexFromString, safeGetArray } from "../utils";
 import { RichStringProcessor } from "../rich-string-processor";
 
@@ -9,7 +9,7 @@ import { RichStringProcessor } from "../rich-string-processor";
  * @param hass HomeAssistant state object
  * @returns Battery name
  */
-export const getName = (config: IBatteryEntityConfig, hass: HomeAssistant, entityData: IMap<any>): string => {
+export const getName = (config: IBatteryEntityConfig, hass: HomeAssistantExt, entityData: IMap<any>): string => {
     if (config.name) {
         const proc = new RichStringProcessor(hass, entityData);
         return proc.process(config.name);

--- a/src/entity-fields/get-secondary-info.ts
+++ b/src/entity-fields/get-secondary-info.ts
@@ -1,4 +1,4 @@
-import { HomeAssistant } from "custom-card-helpers/dist/types";
+import { HomeAssistantExt } from "../type-extensions";
 import { RichStringProcessor } from "../rich-string-processor";
 import { isNumber } from "../utils";
 
@@ -9,7 +9,7 @@ import { isNumber } from "../utils";
  * @param entidyData Entity data
  * @returns Secondary info text
  */
-export const getSecondaryInfo = (config: IBatteryEntityConfig, hass: HomeAssistant, entityData: IMap<any> | undefined): string => {
+export const getSecondaryInfo = (config: IBatteryEntityConfig, hass: HomeAssistantExt, entityData: IMap<any> | undefined): string => {
     if (config.secondary_info) {
         const processor = new RichStringProcessor(hass, entityData);
 

--- a/src/handle-action.ts
+++ b/src/handle-action.ts
@@ -1,4 +1,4 @@
-import { HomeAssistant } from "custom-card-helpers";
+import { HomeAssistantExt } from "./type-extensions";
 import { RichStringProcessor } from "./rich-string-processor";
 
 /**
@@ -24,7 +24,7 @@ export const handleAction = async (
   node: HTMLElement,
   config: ActionConfigParams,
   action: string,
-  hass?: HomeAssistant,
+  hass?: HomeAssistantExt,
   entityData?: IMap<any>,
 ): Promise<void> => {
   // Process KString values in action config if hass is provided
@@ -44,7 +44,7 @@ export const handleAction = async (
  */
 const processActionConfig = (
   config: ActionConfigParams,
-  hass: HomeAssistant,
+  hass: HomeAssistantExt,
   entityData?: IMap<any>,
 ): ActionConfigParams => {
   const processor = new RichStringProcessor(hass, entityData);

--- a/src/rich-string-processor.ts
+++ b/src/rich-string-processor.ts
@@ -1,4 +1,4 @@
-import { HomeAssistant } from "custom-card-helpers";
+import { HomeAssistantExt } from "./type-extensions";
 import { log } from "./utils";
 
 const validEntityDomains = [
@@ -35,7 +35,7 @@ const validEntityDomains = [
  */
  export class RichStringProcessor {
 
-    constructor(private hass: HomeAssistant, private entityData: IMap<any> | undefined) {
+    constructor(private hass: HomeAssistantExt, private entityData: IMap<any> | undefined) {
     }
 
     /**

--- a/src/type-extensions.ts
+++ b/src/type-extensions.ts
@@ -1,12 +1,14 @@
-import { HomeAssistant } from "custom-card-helpers";
+import { HomeAssistant, Theme, Themes } from "custom-card-helpers";
 
 /**
  * https://github.com/home-assistant/frontend/blob/dev/src/types.ts
  */
-export interface HomeAssistantExt extends HomeAssistant {
+export interface HomeAssistantExt extends Omit<HomeAssistant, 'themes'> {
   entities: { [id: string]: EntityRegistryDisplayEntry };
   devices: { [id: string]: DeviceRegistryEntry };
   areas: { [id: string]: AreaRegistryEntry };
+
+  themes: ThemesExt;
 
   formatEntityState(stateObj: any, state?: string): string;
   formatEntityAttributeValue(
@@ -15,6 +17,33 @@ export interface HomeAssistantExt extends HomeAssistant {
     value?: any
   ): string;
   formatEntityAttributeName(stateObj: any, attribute: string): string;
+}
+
+export interface ThemesExt extends Omit<Themes, 'themes'> {
+  /**
+   * Whether dark mode is set
+   */
+  darkMode: boolean;
+  /**
+   * Default dark theme set in Home Assistant
+   */
+  default_dark_theme: string;
+  /**
+   * Current theme set in Home Assistant
+   */
+  theme: string;
+
+  themes: {
+    [theme_name: string]: ThemeExt;
+  } | ThemeMode;
+}
+
+interface ThemeMode {
+  modes: { light: ThemeExt; dark: ThemeExt };
+}
+
+export interface ThemeExt extends Theme {
+  [key: string]: string;
 }
 
 type entityCategory = "config" | "diagnostic";

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -287,6 +287,11 @@ interface IBatteryCardConfig {
      * Filters for auto adding or removing entities
      */
     filter?: { [key in FilterGroups]: FilterSpec[] };
+
+    /**
+     * Name of the theme to apply (must be installed in Home Assistant)
+     */
+    theme?: string;
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -210,3 +210,49 @@ export const extendEntityData = (hass: HomeAssistantExt, entity_id: string, enti
 
     return entityData;
 }
+
+/**
+ * Converts theme object to CSS variables string for inline styles
+ * @param hass Home Assistant object
+ * @param themeName Name of the theme to apply
+ * @returns CSS variables string or undefined if theme not found
+ */
+export const getThemeStyles = (hass: any, themeName: string | undefined): string | undefined => {
+    if (!hass || !themeName || !hass.themes || !hass.themes.themes) {
+        return undefined;
+    }
+
+    const themes = hass.themes.themes;
+    let themeData = themes[themeName];
+
+    if (!themeData) {
+        log(`Theme "${themeName}" not found in Home Assistant`);
+        return undefined;
+    }
+
+    // Check if theme has modes (light/dark)
+    if (themeData.modes) {
+        const isDarkMode = hass.themes.darkMode || false;
+        themeData = isDarkMode ? themeData.modes.dark : themeData.modes.light;
+
+        if (!themeData) {
+            log(`Theme "${themeName}" mode not found (dark: ${isDarkMode})`);
+            return undefined;
+        }
+    }
+
+    // Convert theme properties to CSS variables
+    // Theme objects in HA contain all CSS variables, not just the limited set in Theme interface
+    const cssVars: string[] = [];
+    for (const [key, value] of Object.entries<any>(themeData)) {
+        // Skip the 'modes' property if it exists
+        if (key === 'modes') {
+            continue;
+        }
+        // Theme properties are already in the format we need (some might already have --)
+        const varName = key.startsWith('--') ? key : `--${key}`;
+        cssVars.push(`${varName}: ${value}`);
+    }
+
+    return cssVars.join('; ');
+}

--- a/test/unit/theme.test.ts
+++ b/test/unit/theme.test.ts
@@ -1,0 +1,147 @@
+import { getThemeStyles } from "../../src/utils";
+
+describe("Theme support", () => {
+    it("should return undefined when hass is undefined", () => {
+        const result = getThemeStyles(undefined, "waves");
+        expect(result).toBeUndefined();
+    });
+
+    it("should return undefined when theme name is undefined", () => {
+        const hass = { themes: { themes: {} } };
+        const result = getThemeStyles(hass, undefined);
+        expect(result).toBeUndefined();
+    });
+
+    it("should return undefined when theme doesn't exist", () => {
+        const hass = {
+            themes: {
+                themes: {
+                    "slate": { "--primary-color": "#ff0000" }
+                }
+            }
+        };
+        const result = getThemeStyles(hass, "waves");
+        expect(result).toBeUndefined();
+    });
+
+    it("should convert theme properties to CSS variables", () => {
+        const hass = {
+            themes: {
+                themes: {
+                    "waves": {
+                        "primary-color": "#0288D1",
+                        "accent-color": "#0288D1",
+                        "--custom-var": "#ffffff"
+                    }
+                }
+            }
+        };
+        const result = getThemeStyles(hass, "waves");
+        expect(result).toBeDefined();
+        expect(result).toContain("--primary-color: #0288D1");
+        expect(result).toContain("--accent-color: #0288D1");
+        expect(result).toContain("--custom-var: #ffffff");
+    });
+
+    it("should handle themes with many CSS variables", () => {
+        const hass = {
+            themes: {
+                themes: {
+                    "slate": {
+                        "primary-color": "#2196F3",
+                        "text-primary-color": "#FFFFFF",
+                        "paper-card-background-color": "#1E1E1E",
+                        "ha-card-background": "#1E1E1E",
+                        "--disabled-text-color": "#6F6F6F"
+                    }
+                }
+            }
+        };
+        const result = getThemeStyles(hass, "slate");
+        expect(result).toBeDefined();
+        expect(result).toContain("--primary-color: #2196F3");
+        expect(result).toContain("--text-primary-color: #FFFFFF");
+        expect(result).toContain("--paper-card-background-color: #1E1E1E");
+        expect(result).toContain("--ha-card-background: #1E1E1E");
+        expect(result).toContain("--disabled-text-color: #6F6F6F");
+    });
+
+    it("should handle themes with light mode when darkMode is false", () => {
+        const hass = {
+            themes: {
+                darkMode: false,
+                themes: {
+                    "adaptive": {
+                        modes: {
+                            light: {
+                                "primary-color": "#FF5722",
+                                "text-primary-color": "#000000"
+                            },
+                            dark: {
+                                "primary-color": "#2196F3",
+                                "text-primary-color": "#FFFFFF"
+                            }
+                        }
+                    }
+                }
+            }
+        };
+        const result = getThemeStyles(hass, "adaptive");
+        expect(result).toBeDefined();
+        expect(result).toContain("--primary-color: #FF5722");
+        expect(result).toContain("--text-primary-color: #000000");
+        expect(result).not.toContain("#2196F3");
+        expect(result).not.toContain("#FFFFFF");
+    });
+
+    it("should handle themes with dark mode when darkMode is true", () => {
+        const hass = {
+            themes: {
+                darkMode: true,
+                themes: {
+                    "adaptive": {
+                        modes: {
+                            light: {
+                                "primary-color": "#FF5722",
+                                "text-primary-color": "#000000"
+                            },
+                            dark: {
+                                "primary-color": "#2196F3",
+                                "text-primary-color": "#FFFFFF"
+                            }
+                        }
+                    }
+                }
+            }
+        };
+        const result = getThemeStyles(hass, "adaptive");
+        expect(result).toBeDefined();
+        expect(result).toContain("--primary-color: #2196F3");
+        expect(result).toContain("--text-primary-color: #FFFFFF");
+        expect(result).not.toContain("#FF5722");
+        expect(result).not.toContain("#000000");
+    });
+
+    it("should default to light mode when darkMode is not set", () => {
+        const hass = {
+            themes: {
+                themes: {
+                    "adaptive": {
+                        modes: {
+                            light: {
+                                "primary-color": "#FF5722"
+                            },
+                            dark: {
+                                "primary-color": "#2196F3"
+                            }
+                        }
+                    }
+                }
+            }
+        };
+        const result = getThemeStyles(hass, "adaptive");
+        expect(result).toBeDefined();
+        expect(result).toContain("--primary-color: #FF5722");
+        expect(result).not.toContain("#2196F3");
+    });
+});


### PR DESCRIPTION
#670 

```yaml
type: custom:battery-state-card
theme: slate  # Apply the "slate" theme
entities:
  - sensor.bedroom_motion_battery_level
  - sensor.bathroom_motion_battery_level
```