### PR TITLE
Support for custom CSS styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ These options can be specified both per-entity and at the top level (affecting a
 | debug | boolean \| string | `false` | v3.2.0 | Whether to show debug output (all available entity data). You can use entity_id if you want to debug specific one.
 | respect_visibility_setting | boolean | `true` | v3.3.0 | Whether to hide entities which are marked in the UI as hidden on dashboards.
 | unpack | boolean | `false` | v3.4.0 | Whether to unpack entities that have an `entity_id` array attribute (e.g. sensor groups) into separate batteries. ([example](#unpacking-grouped-entities))
+| style | string |  | v3.4.0 | Custom CSS rules injected into the element's shadow DOM. Allows targeting inner elements (e.g. `.name`, `.state`, `.icon`). Can be used together with card-level `theme`. ([example](#custom-styles))
 
 ### Keyword string (KString)
 
@@ -787,6 +788,62 @@ entities:
 ```
 
 **Light/Dark Mode Support**: The card automatically detects if your theme has separate light and dark modes and applies the appropriate mode based on Home Assistant's dark mode setting.
+
+### Custom styles
+
+You can use the `style` property to inject custom CSS rules into the component's shadow DOM. This allows you to target inner HTML elements like `.name`, `.state`, `.icon`, `ha-card`, etc.
+
+#### Card-level custom styles
+
+```yaml
+type: custom:battery-state-card
+style: |
+  ha-card {
+    background: #1E1E1E;
+  }
+  .name {
+    font-weight: bold;
+  }
+entities:
+  - sensor.bedroom_motion_battery_level
+  - sensor.bathroom_motion_battery_level
+```
+
+You can also use CSS variables to customize the look:
+
+```yaml
+type: custom:battery-state-card
+style: ":host { --ha-card-background: #1E1E1E; --primary-text-color: #E0E0E0; }"
+entities:
+  - sensor.bedroom_motion_battery_level
+```
+
+#### Per-entity custom styles
+
+Since `style` is a [common option](#common-options), it can be set per-entity to style individual battery elements:
+
+```yaml
+type: custom:battery-state-card
+title: "Custom styled entities"
+entities:
+  - entity: sensor.bedroom_battery
+    style: ".name { color: red; }"
+  - sensor.bathroom_battery  # no custom style
+```
+
+#### Combining with themes
+
+You can combine `style` with `theme`. Theme CSS variables are applied as inline styles on the host element, while custom `style` rules are injected into the shadow DOM — so both work independently:
+
+```yaml
+type: custom:battery-state-card
+theme: slate
+style: |
+  :host { --primary-color: #ff5722; }
+  .name { font-style: italic; }
+entities:
+  - sensor.bedroom_motion_battery_level
+```
 
 ### Unpacking grouped entities
 

--- a/src/battery-provider.ts
+++ b/src/battery-provider.ts
@@ -23,6 +23,7 @@ const entititesGlobalProps: (keyof IBatteryEntityConfig)[] = [
     "tap_action",
     "value_override",
     "unit",
+    "style",
 ];
 
 /**
@@ -60,7 +61,7 @@ export class BatteryProvider {
      */
     private initialized: boolean = false;
 
-    constructor(private config: IBatteryCardConfig) {
+    constructor(private config: IBatteryStateCardConfig) {
         this.include = config.filter?.include?.map(createFilter);
         this.exclude = config.filter?.exclude?.map(createFilter);
 

--- a/src/custom-elements/battery-state-card.ts
+++ b/src/custom-elements/battery-state-card.ts
@@ -14,13 +14,19 @@ import defaultConfig from "../default-config";
 /**
  * Battery Card element
  */
-export class BatteryStateCard extends LovelaceCard<IBatteryCardConfig> {
+export class BatteryStateCard extends LovelaceCard<IBatteryStateCardConfig> {
 
     /**
      * Card title
      */
     @property({attribute: false})
     public header: string | undefined;
+
+    /**
+     * Dynamic styles from theme and custom style config
+     */
+    @property({attribute: false})
+    public dynamicStyles: string = "";
 
     /**
      * List of entity IDs to render (without group)
@@ -68,13 +74,12 @@ export class BatteryStateCard extends LovelaceCard<IBatteryCardConfig> {
 
         this.header = this.config.title;
 
-        // Apply theme styles directly to host element
+        // Apply theme styles to host element via style attribute
         const themeStyles = getThemeStyles(<any>this.hass, this.config.theme);
-        if (themeStyles) {
-            this.style.cssText = themeStyles;
-        } else {
-            this.style.cssText = "";
-        }
+        this.style.cssText = themeStyles || "";
+
+        // Custom style config goes into shadow DOM style block
+        this.dynamicStyles = this.config.style || "";
 
         this.batteries = this.batteryProvider.getBatteries();
 

--- a/src/custom-elements/battery-state-card.views.ts
+++ b/src/custom-elements/battery-state-card.views.ts
@@ -35,6 +35,7 @@ export const collapsableWrapper = (model: IBatteryGroup, batteries: IBatteryColl
 
 
 export const cardHtml = (model: BatteryStateCard) => html`
+${model.dynamicStyles ? html`<style>${model.dynamicStyles}</style>` : ""}
 <ha-card>
     ${header(model.header)}
     <div class="card-content">

--- a/src/custom-elements/battery-state-entity.ts
+++ b/src/custom-elements/battery-state-entity.ts
@@ -57,6 +57,12 @@ export class BatteryStateEntity extends LovelaceCard<IBatteryEntityConfig> {
     public iconColor: string;
 
     /**
+     * Dynamic styles from custom style config
+     */
+    @property({ attribute: false })
+    public dynamicStyles: string = "";
+
+    /**
      * Tap action
      */
     @property({ attribute: false })
@@ -127,6 +133,7 @@ export class BatteryStateEntity extends LovelaceCard<IBatteryEntityConfig> {
         this.secondaryInfo = getSecondaryInfo(this.config, this.hass, this.entityData);
         this.icon = getIcon(this.config, level, isCharging, this.hass);
         this.iconColor = getColorForBatteryLevel(this.config, level, isCharging);
+        this.dynamicStyles = this.config.style || "";
     }
 
     connectedCallback() {

--- a/src/custom-elements/battery-state-entity.views.ts
+++ b/src/custom-elements/battery-state-entity.views.ts
@@ -71,6 +71,7 @@ export const customOrDefaultIcon = (model: BatteryStateEntity) => {
 }
 
 export const batteryHtml = (model: BatteryStateEntity) => html`
+${model.dynamicStyles ? html`<style>${model.dynamicStyles}</style>` : ""}
 ${customOrDefaultIcon(model)}
 <div class="name truncate">
     ${model.name}

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -265,6 +265,11 @@ interface IBatteryEntityConfig {
      * Whether to unpack entity_id attribute and create separate batteries for each entity
      */
     unpack?: boolean,
+
+    /**
+     * Custom CSS styles to apply to the element
+     */
+    style?: string,
 }
 
 interface IBatteryCardConfig {
@@ -297,17 +302,12 @@ interface IBatteryCardConfig {
      * Name of the theme to apply (must be installed in Home Assistant)
      */
     theme?: string;
-
-    /**
-     * Whether to unpack entities having entity_id array attribute into separate batteries
-     */
-    unpack?: boolean;
 }
 
 /**
  * Battery card root config
  */
-interface IBatteryStateCardConfig extends IBatteryCardConfig, IBatteryEntityConfig  {
+interface IBatteryStateCardConfig extends IBatteryCardConfig, Omit<IBatteryEntityConfig, "entity"> {
 
 }
 

--- a/test/integration/card/style.test.ts
+++ b/test/integration/card/style.test.ts
@@ -1,0 +1,146 @@
+import { expect } from '@esm-bundle/chai';
+import { BatteryStateCard } from "../../../src/custom-elements/battery-state-card";
+import { BatteryStateEntity } from "../../../src/custom-elements/battery-state-entity";
+import { CardElements, HomeAssistantMock } from "../../helpers";
+
+const getStyleContent = (elem: HTMLElement): string => {
+    const styleTag = elem.shadowRoot?.querySelector("style");
+    return styleTag?.textContent || "";
+};
+
+describe("Custom styles", () => {
+    it("applies custom style to the card shadow DOM", async () => {
+        const hass = new HomeAssistantMock<BatteryStateCard>();
+        hass.addEntity("Battery 1", "90");
+
+        const cardElem = hass.addCard("battery-state-card", {
+            title: "Test",
+            style: ".card-header { color: red; }",
+            entities: ["battery_1"]
+        });
+
+        await cardElem.cardUpdated;
+        await cardElem.updateComplete;
+
+        expect(getStyleContent(cardElem)).to.contain(".card-header { color: red; }");
+    });
+
+    it("theme is applied via inline style attribute", async () => {
+        const hass = new HomeAssistantMock<BatteryStateCard>();
+        hass.addEntity("Battery 1", "90");
+
+        (<any>hass.hass).themes = {
+            darkMode: false,
+            themes: {
+                "slate": {
+                    "primary-color": "#2196F3"
+                }
+            }
+        };
+
+        const cardElem = hass.addCard("battery-state-card", {
+            title: "Test",
+            theme: "slate",
+            entities: ["battery_1"]
+        });
+
+        await cardElem.cardUpdated;
+
+        expect(cardElem.style.cssText).to.contain("--primary-color: #2196F3");
+    });
+
+    it("theme and custom style use separate mechanisms", async () => {
+        const hass = new HomeAssistantMock<BatteryStateCard>();
+        hass.addEntity("Battery 1", "90");
+
+        (<any>hass.hass).themes = {
+            darkMode: false,
+            themes: {
+                "slate": {
+                    "primary-color": "#2196F3"
+                }
+            }
+        };
+
+        const cardElem = hass.addCard("battery-state-card", {
+            title: "Test",
+            theme: "slate",
+            style: ".card-content { background: #333; }",
+            entities: ["battery_1"]
+        });
+
+        await cardElem.cardUpdated;
+        await cardElem.updateComplete;
+
+        // theme in inline style attribute
+        expect(cardElem.style.cssText).to.contain("--primary-color: #2196F3");
+        // custom style in shadow DOM style block
+        expect(getStyleContent(cardElem)).to.contain(".card-content { background: #333; }");
+    });
+
+    it("no style block when style is not set", async () => {
+        const hass = new HomeAssistantMock<BatteryStateCard>();
+        hass.addEntity("Battery 1", "90");
+
+        const cardElem = hass.addCard("battery-state-card", {
+            title: "Test",
+            entities: ["battery_1"]
+        });
+
+        await cardElem.cardUpdated;
+        await cardElem.updateComplete;
+
+        expect(cardElem.shadowRoot?.querySelector("style")).to.be.null;
+    });
+
+    it("applies custom style to entity element shadow DOM", async () => {
+        const hass = new HomeAssistantMock<BatteryStateCard>();
+        hass.addEntity("Battery 1", "90");
+
+        const cardElem = hass.addCard("battery-state-card", {
+            title: "Test",
+            entities: [
+                { entity: "battery_1", style: ".name { font-weight: bold; }" }
+            ]
+        });
+
+        await cardElem.cardUpdated;
+        await cardElem.updateComplete;
+
+        const entityElem = cardElem.shadowRoot!.querySelectorAll<BatteryStateEntity>(".card-content > * > battery-state-entity")[0];
+        expect(getStyleContent(entityElem)).to.contain(".name { font-weight: bold; }");
+    });
+
+    it("card-level style propagates to entity elements", async () => {
+        const hass = new HomeAssistantMock<BatteryStateCard>();
+        hass.addEntity("Battery 1", "90");
+        hass.addEntity("Battery 2", "50");
+
+        const cardElem = hass.addCard("battery-state-card", {
+            title: "Test",
+            style: ".state { color: blue; }",
+            entities: ["battery_1", "battery_2"]
+        });
+
+        await cardElem.cardUpdated;
+        await cardElem.updateComplete;
+
+        const entities = cardElem.shadowRoot!.querySelectorAll<BatteryStateEntity>(".card-content > * > battery-state-entity");
+        expect(getStyleContent(entities[0])).to.contain(".state { color: blue; }");
+        expect(getStyleContent(entities[1])).to.contain(".state { color: blue; }");
+    });
+
+    it("no style block in entity when style is not set", async () => {
+        const hass = new HomeAssistantMock<BatteryStateEntity>();
+        hass.addEntity("Battery 1", "90");
+
+        const cardElem = hass.addCard("battery-state-entity", {
+            entity: "battery_1",
+        });
+
+        await cardElem.cardUpdated;
+        await cardElem.updateComplete;
+
+        expect(cardElem.shadowRoot?.querySelector("style")).to.be.null;
+    });
+});


### PR DESCRIPTION
#776 

```yaml
type: custom:battery-state-card
style: |
  ha-card {
    background: #1E1E1E;
  }
  .name {
    font-weight: bold;
  }
entities:
  - sensor.bedroom_motion_battery_level
  - sensor.bathroom_motion_battery_level
```