### PR TITLE
Smart charging state detection

### DIFF
--- a/src/entity-fields/charging-state.ts
+++ b/src/entity-fields/charging-state.ts
@@ -59,9 +59,14 @@ const getDefaultChargingState = (hass?: HomeAssistantExt, siblings?: ISiblingEnt
     }
 
     for (const sibling of siblings) {
-        // enum sensor with charging states (higher priority - return immediately)
+        // enum sensor with charging states
         if (sibling.device_class === "enum") {
             return ["charging", "full"].includes(hass.states[sibling.entity_id]?.state);
+        }
+
+        // binary_sensor with device_class: plug
+        if (sibling.entity_id.startsWith("binary_sensor.") && sibling.device_class === "plug") {
+            return hass.states[sibling.entity_id]?.state === "on";
         }
     }
 

--- a/test/unit/entity-fields/charging-state.test.ts
+++ b/test/unit/entity-fields/charging-state.test.ts
@@ -192,4 +192,78 @@ describe("Charging state", () => {
         expect(isCharging).toBe(true);
     })
 
+    test.each([
+        ["on", true],
+        ["off", false],
+    ])("default charging state from binary_sensor plug on same device (state: %s)", (plugState: string, expected: boolean) => {
+        const hassMock = new HomeAssistantMock(true);
+        const batteryEntity = hassMock.addEntity("Battery level", "80", {}, "sensor");
+        const plugEntity = hassMock.addEntity("Charger plug", plugState, { device_class: "plug" }, "binary_sensor");
+        const siblings = [makeSibling(plugEntity.entity_id, "plug")];
+
+        const isCharging = getChargingState(
+            { entity: batteryEntity.entity_id },
+            "80",
+            hassMock.hass,
+            siblings,
+        );
+
+        expect(isCharging).toBe(expected);
+    })
+
+    test("default charging state: enum entity takes precedence over plug on same device", () => {
+        const hassMock = new HomeAssistantMock(true);
+        const batteryEntity = hassMock.addEntity("Battery level", "80", {}, "sensor");
+        const enumEntity = hassMock.addEntity("Battery state", "discharging", { device_class: "enum" }, "sensor");
+        const plugEntity = hassMock.addEntity("Charger plug", "on", { device_class: "plug" }, "binary_sensor");
+        const siblings = [
+            makeSibling(enumEntity.entity_id, "enum"),
+            makeSibling(plugEntity.entity_id, "plug"),
+        ];
+
+        const isCharging = getChargingState(
+            { entity: batteryEntity.entity_id },
+            "80",
+            hassMock.hass,
+            siblings,
+        );
+
+        // enum entity found first with "discharging" ? not a charging state
+        expect(isCharging).toBe(false);
+    })
+
+    test("plug entity on different device is ignored", () => {
+        const hassMock = new HomeAssistantMock(true);
+        const batteryEntity = hassMock.addEntity("Battery level", "80", {}, "sensor");
+        hassMock.addEntity("Other plug", "on", { device_class: "plug" }, "binary_sensor");
+        // siblings is empty because plug is on a different device
+        const siblings: ISiblingEntity[] = [];
+
+        const isCharging = getChargingState(
+            { entity: batteryEntity.entity_id },
+            "80",
+            hassMock.hass,
+            siblings,
+        );
+
+        expect(isCharging).toBe(false);
+    })
+
+    test("plug entity without device_class plug is ignored", () => {
+        const hassMock = new HomeAssistantMock(true);
+        const batteryEntity = hassMock.addEntity("Battery level", "80", {}, "sensor");
+        const binaryEntity = hassMock.addEntity("Some binary", "on", {}, "binary_sensor");
+        // no device_class ? undefined
+        const siblings = [makeSibling(binaryEntity.entity_id)];
+
+        const isCharging = getChargingState(
+            { entity: batteryEntity.entity_id },
+            "80",
+            hassMock.hass,
+            siblings,
+        );
+
+        expect(isCharging).toBe(false);
+    })
+
 });


### PR DESCRIPTION
In the past we were looking for "*_battery_state" entity with the same prefix of entity name. This was far from being perfect as pretty often entity names are random - people don't pay attention to them.

Now we are looking for entities related to the same device. And we try to detect whether entity is charging from two sources:
1. Sensor entity with "enum" device class and with values matching charging battery states e.g. "charging"
    Such sensor is created for example by companion app integration
3. Binary sensor with "plug" device class
    Such sensors are created for example by fully kiosk browser integration

