### PR TITLE
Battery notes integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1091,6 +1091,68 @@ colors:
 ```
 
 
+## Battery Notes
+
+This card has built-in support for the [Battery Notes](https://github.com/andrew-codechimp/HA-Battery-Notes) integration. Battery Notes is a popular HACS integration that adds additional information about battery devices, such as battery type and quantity.
+
+When Battery Notes is installed it creates additional entities for each device (on the `battery_notes` platform). The card handles them in two ways:
+
+1. **Automatic filtering** - Battery Notes entities are automatically excluded when entities are discovered via include filters, preventing duplicate entries in the card.
+2. **Extra attributes** - Battery Notes data (e.g. `battery_type`, `battery_quantity`) is resolved from sibling entities and made available under the `battery_notes` key in entity data. This means you can use these values in templates such as `secondary_info`.
+
+This feature is **enabled by default**. If something doesn't work as expected you can turn it off:
+
+```yaml
+type: custom:battery-state-card
+battery_notes_enabled: false
+```
+
+Or per-entity:
+
+```yaml
+type: custom:battery-state-card
+entities:
+  - entity: sensor.my_device_battery
+    battery_notes_enabled: false
+```
+
+When enabled, you can reference Battery Notes attributes in `secondary_info`:
+
+```yaml
+type: custom:battery-state-card
+secondary_info: "{battery_notes.battery_type}"
+filter:
+  include:
+    - name: attributes.device_class
+      value: battery
+```
+
+You can also group batteries by battery type using [group filters](#group-object):
+
+```yaml
+type: custom:battery-state-card
+secondary_info: "{battery_notes.battery_type}"
+filter:
+  include:
+    - name: attributes.device_class
+      value: battery
+sort:
+  by: state
+collapse:
+  - name: "CR2032 ({count})"
+    icon: mdi:battery
+    filter:
+      - name: battery_notes.battery_type
+        value: CR2032
+  - name: "AAA ({count})"
+    icon: mdi:battery
+    filter:
+      - name: battery_notes.battery_type
+        value: AAA
+  - name: "Other ({count})"
+    icon: mdi:battery-unknown
+```
+
 ## Installation
 
 Once added to [HACS](https://community.home-assistant.io/t/custom-component-hacs/121727) add the following resource to your **lovelace** configuration (if you have yaml mode active)

--- a/src/battery-provider.ts
+++ b/src/battery-provider.ts
@@ -2,7 +2,7 @@ import { log, safeGetConfigArrayOfObjects } from "./utils";
 import { BatteryStateEntity } from "./custom-elements/battery-state-entity";
 import { createFilter, Filter } from "./filter";
 import { HomeAssistantExt } from "./type-extensions";
-import { hassRegistryCache } from "./hass-registry-cache";
+import { BATTERY_NOTES_PLATFORM, hassRegistryCache } from "./hass-registry-cache";
 
 /**
  * Properties which should be copied over to individual entities from the card
@@ -24,6 +24,7 @@ const entititesGlobalProps: (keyof IBatteryEntityConfig)[] = [
     "value_override",
     "unit",
     "style",
+    "battery_notes_enabled",
 ];
 
 /**
@@ -176,8 +177,9 @@ export class BatteryProvider {
         }
 
         const advancedInclude = this.include.some(filter => filter.is_advanced);
+        const filterBatteryNotes = this.config.battery_notes_enabled !== false;
 
-        // Collect required registry fields from include filters
+        // Collect required registry fields from include filters, we do it to optimize the initialization stage by fetching only necessary data
         const requiredFields = advancedInclude
             ? [...new Set(
                 this.include
@@ -196,6 +198,7 @@ export class BatteryProvider {
             let entityData = <IMap<any>>{};
             if (advancedInclude) {
                 entityData = { ...hass.states[entityId] };
+                // getting "partial" extended data based on filters requirements
                 const extData = hassRegistryCache.getExtendedData(hass, entityId, requiredFields);
                 if (extData.display) {
                     entityData["display"] = extData.display;
@@ -206,6 +209,15 @@ export class BatteryProvider {
 
             // check if entity matches filter conditions
             if (this.include!.some(filter => filter.isValid(advancedInclude ? entityData : hass.states[entityId]))) {
+
+                // Filter out battery_notes entities (duplicates created by the integration)
+                if (filterBatteryNotes) {
+                    const display = hassRegistryCache.getDisplay(hass, entityId);
+                    if (display?.platform === BATTERY_NOTES_PLATFORM) {
+                        return;
+                    }
+                }
+
                 this.batteries[entityId] = this.createBattery({ entity: entityId });
             }
         });

--- a/src/custom-elements/battery-state-entity.ts
+++ b/src/custom-elements/battery-state-entity.ts
@@ -114,6 +114,14 @@ export class BatteryStateEntity extends LovelaceCard<IBatteryEntityConfig> {
                 this.entityData["device"] = extData.device;
                 this.entityData["area"] = extData.area;
                 this.entityData["siblings"] = extData.siblings;
+
+                // battery_notes data is resolved on every update (not cached) as it can change dynamically
+                if (this.config.battery_notes_enabled !== false && extData?.siblings && extData.siblings.length > 0) {
+                    const batteryNotesData = hassRegistryCache.resolveBatteryNotesData(this.hass, extData.siblings);
+                    if (batteryNotesData) {
+                        this.entityData["battery_notes"] = batteryNotesData;
+                    }
+                }
             }
 
             this.showEntity();

--- a/src/hass-registry-cache.ts
+++ b/src/hass-registry-cache.ts
@@ -1,5 +1,7 @@
 import { AreaRegistryEntry, DeviceRegistryEntry, EntityRegistryDisplayEntry, HomeAssistantExt } from "./type-extensions";
 
+export const BATTERY_NOTES_PLATFORM = "battery_notes";
+
 /**
  * Caches Home Assistant registry data (areas, devices, entity display entries)
  * individually by their IDs, and provides extended entity data including siblings.
@@ -109,6 +111,34 @@ export class HassRegistryCache {
                     state_class: state?.attributes?.state_class,
                 };
             });
+    }
+
+    /**
+     * Resolves battery_notes attributes from sibling entities on the same device.
+     * This is NOT cached as battery_notes data can change dynamically.
+     */
+    resolveBatteryNotesData(hass: HomeAssistantExt, siblings: ISiblingEntity[]): IMap<any> | undefined {
+        if (!siblings || siblings.length === 0) {
+            return undefined;
+        }
+
+        for (const sibling of siblings) {
+            const display = this.getDisplay(hass, sibling.entity_id);
+            if (display?.platform !== BATTERY_NOTES_PLATFORM) {
+                continue;
+            }
+
+            const state = hass.states[sibling.entity_id];
+            if (!state ||
+                state.attributes?.device_class !== "battery" ||
+                state.attributes?.battery_quantity === undefined) {
+                continue;
+            }
+
+            return state.attributes;
+        }
+
+        return undefined;
     }
 }
 

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -179,6 +179,7 @@ interface IEntityRegistryCache {
     device?: import("./type-extensions").DeviceRegistryEntry;
     area?: import("./type-extensions").AreaRegistryEntry;
     siblings: ISiblingEntity[];
+    battery_notes?: IMap<any>;
 }
 
 interface IBatteryEntityConfig {
@@ -287,6 +288,11 @@ interface IBatteryEntityConfig {
      * Custom CSS styles to apply to the element
      */
     style?: string,
+
+    /**
+     * Whether to use battery_notes integration data (filter duplicates, add attributes)
+     */
+    battery_notes_enabled?: boolean;
 }
 
 interface IBatteryCardConfig {


### PR DESCRIPTION
Now all of the battery notes attribs are available under `battery_notes`. No more duped entities!

```yaml
type: custom:battery-state-card
secondary_info: "{battery_notes.battery_type}"
filter:
  include:
    - name: attributes.device_class
      value: battery
```